### PR TITLE
Improve validation of curve and mapping keys

### DIFF
--- a/pyETM/utils/categorisation.py
+++ b/pyETM/utils/categorisation.py
@@ -1,25 +1,27 @@
+import warnings
 import logging
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
+
 def categorise_curves(curves, mapping, columns=None,
                       include_index=False, **kwargs):
-    """Categorize the hourly curves for a specific dataframe 
-    with a specific mapping. 
-    
+    """Categorize the hourly curves for a specific dataframe
+    with a specific mapping.
+
     # IMPORTANT #
     -------------
     Assigns a negative sign to demand to ensure that demand and supply keys
     with the same key mapping can be aggregated.
-    
+
     Parameters
     ----------
     curves : DataFrame
-        The hourly curves for which the 
+        The hourly curves for which the
         categorization is applied.
     mapping : DataFrame or str
-        DataFrame with mapping of ETM keys in index and mapping 
+        DataFrame with mapping of ETM keys in index and mapping
         values in columns. Alternatively a string to a csv-file
         can be passed.
     columns : list, default None
@@ -27,33 +29,37 @@ def categorise_curves(curves, mapping, columns=None,
         in the mapping. Defaults to all columns in mapping.
     include_index : bool, default False
         Include the original ETM keys in the resulting mapping.
-    **kwargs are passed to pd.read_csv when a filename is 
+    **kwargs are passed to pd.read_csv when a filename is
     passed in the mapping argument.
-    
+
     Return
     ------
     curves : DataFrame
-        DataFrame with the categorized curves of the 
+        DataFrame with the categorized curves of the
         specified carrier.
     """
-        
+
     # load categorization
     if isinstance(mapping, str):
         mapping = pd.read_csv(mapping, *args, **kwargs)
-    
+
     if isinstance(mapping, pd.Series):
         mapping = mapping.to_frame()
         columns = mapping.columns
-        
-    # check if passed curves contains columns not specified in cat 
-    for item in curves.columns[~curves.columns.isin(mapping.index)]:
-        raise KeyError(f'"{item}" is not present in the ' + 
-                       f'curve categorization')
+
+    # check if passed curves contains columns not specified in cat
+    missing_curves = curves.columns[~curves.columns.isin(mapping.index)].tolist()
+    if missing_curves:
+        raise KeyError(
+            "The following are present in the curves but not in the categorization mapping: "
+            + ", ".join(missing_curves))
 
     # check if cat specifies keys not in passed curves
-    for item in mapping.index[~mapping.index.isin(curves.columns)]:
-        raise KeyError(f'"{item}" is not present in the ' +
-                       f'returned ETM curves')
+    superfluous_curves = mapping.index[~mapping.index.isin(curves.columns)].tolist()
+    if superfluous_curves:
+        warnings.warn(
+            "The following are present in the categorization mapping but not in the curves: "
+            + ", ".join(superfluous_curves))
 
     # copy curves
     curves = curves.copy()
@@ -61,17 +67,17 @@ def categorise_curves(curves, mapping, columns=None,
     # assign negative sign to demand
     cols = curves.columns.str.contains(".input (MW)", regex=False)
     curves.loc[:, cols] = -curves.loc[:, cols]
-    
+
     # subset columns
     if columns is not None:
 
         # check columns argument
         if isinstance(columns, str):
             columns = [columns]
-        
+
         # subset categorization
         mapping = mapping[columns]
-        
+
     # include index in mapping
     if include_index is True:
 
@@ -83,14 +89,14 @@ def categorise_curves(curves, mapping, columns=None,
 
         # extract column
         column = columns[0]
-        
+
         # apply mapping to curves
         curves.columns = curves.columns.map(mapping[column])
         curves.columns.name = column
-        
+
         # aggregate over mapping
         curves = curves.groupby(by=column, axis=1).sum()
-        
+
     else:
 
         # make multiindex and midx mapper
@@ -107,9 +113,10 @@ def categorise_curves(curves, mapping, columns=None,
 
     return curves
 
+
 def diagnose_categorisation(mapping, curves, warn=True):
     """Diagnose categorisation keys
-    
+
     Parameters
     ----------
     mapping : dict or Series
@@ -118,30 +125,30 @@ def diagnose_categorisation(mapping, curves, warn=True):
         Uncategorised ETM curves.
     warn : bool, default True
         Raise warning if check failed."""
-    
+
     # initialize dict
     diagnosis = {}
-    
+
     # convert dict to series
     if isinstance(mapping, dict):
         mapping = pd.Series(mapping)
-    
+
     # identify invalid entries
     errors = mapping.index[~mapping.index.isin(curves.columns)]
 
     # store errors
     if not errors.empty:
         diagnosis["invalid"] = set(errors)
-    
+
     # identify missing entries
     errors = curves.columns[~curves.columns.isin(mapping.index)]
 
     # store errors
     if not errors.empty:
         diagnosis["missing"] = set(errors)
-        
+
     # raise warning
     if bool(diagnosis) & warn:
         logger.warning("regionalisation contains errors")
-        
+
     return diagnosis

--- a/pyETM/utils/categorisation.py
+++ b/pyETM/utils/categorisation.py
@@ -1,4 +1,3 @@
-import warnings
 import logging
 import pandas as pd
 

--- a/pyETM/utils/categorisation.py
+++ b/pyETM/utils/categorisation.py
@@ -57,7 +57,7 @@ def categorise_curves(curves, mapping, columns=None,
     # check if cat specifies keys not in passed curves
     superfluous_curves = mapping.index[~mapping.index.isin(curves.columns)].tolist()
     if superfluous_curves:
-        warnings.warn(
+        logger.warning(
             "The following are present in the categorization mapping but not in the curves: "
             + ", ".join(superfluous_curves))
 


### PR DESCRIPTION
Changes:
* Prints all curves that are missing in the mapping at once, rather than one by one.
* Throws a warning rather than exception for all curve keys included in the mapping but missing in the curve file.

First change helps for debugging as it gives all violations at once.
Second change: I prefer a warning here rather than an exception, unused keys in the mapping have no effect on the hourly curves so no data is 'lost' here.

Curious what you think @robcalon 

Not urgent btw