### PR TITLE
Metadata fixes

### DIFF
--- a/examples/create_and_update_a_scenario.ipynb
+++ b/examples/create_and_update_a_scenario.ipynb
@@ -20,21 +20,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "3ada4b30",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Environment setup complete\n",
-      "  Using ETM API at     http://localhost:3000/api/v3\n",
-      "  Token loaded?        True\n",
-      "API connection ready\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from example_helpers import setup_notebook\n",
     "from pyetm.models import Scenario\n",
@@ -52,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "4770e6a9",
    "metadata": {},
    "outputs": [],
@@ -63,7 +52,7 @@
     "    area_code=\"nl2019\",\n",
     "    end_year=2050,\n",
     "    private=False,\n",
-    "    keep_compatible=True,\n",
+    "    keep_compatible=False,\n",
     "    source=\"pyetm\")"
    ]
   },
@@ -77,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "5a1549ac",
    "metadata": {},
    "outputs": [],
@@ -97,24 +86,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "7fc4dc21",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Area: nl2019\n",
-      "End year: 2050\n",
-      "Start year: 2019\n",
-      "Version: latest\n",
-      "Modified inputs: 2\n",
-      "First input: co_firing_biocoal_share = 80.0\n",
-      "Second input: co_firing_coal_share = 20.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"Area: {scenario.area_code}\")\n",
     "print(f\"End year: {scenario.end_year}\")\n",
@@ -136,55 +111,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "c6a65f6a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'scenario': {'id': 2690527,\n",
-       "  'created_at': '2025-07-18T13:10:10.000Z',\n",
-       "  'updated_at': '2025-07-18T13:10:10.000Z',\n",
-       "  'end_year': 2050,\n",
-       "  'keep_compatible': True,\n",
-       "  'private': True,\n",
-       "  'area_code': 'nl2019',\n",
-       "  'source': 'test_change',\n",
-       "  'user_values': {'co_firing_biocoal_share': 80.0},\n",
-       "  'balanced_values': {'co_firing_coal_share': 20.0},\n",
-       "  'metadata': {'title': 'Test scenario!',\n",
-       "   'description': 'Updated scenario description',\n",
-       "   'author': 'Ernie'},\n",
-       "  'active_couplings': [],\n",
-       "  'start_year': 2019,\n",
-       "  'inactive_couplings': [],\n",
-       "  'scaling': None,\n",
-       "  'template': None,\n",
-       "  'url': 'http://localhost:3000/api/v3/scenarios/2690527'},\n",
-       " 'gqueries': {}}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "scenario.update_metadata({\n",
-    "    \"private\": True,\n",
-    "    \"keep_compatible\": True,\n",
-    "    \"source\": \"test_change\"\n",
-    "})\n",
+    "scenario.update_metadata(\n",
+    "    private= True,\n",
+    "    keep_compatible= True,\n",
+    "    source= \"test_change_source\",\n",
+    "    end_year= 2040\n",
+    ")\n",
     "\n",
     "# You can also update the metadata attribute\n",
-    "scenario.update_metadata({\n",
-    "    \"metadata\": {\n",
+    "scenario.update_metadata(\n",
+    "    metadata= {\n",
     "        \"title\": \"Test scenario!\",\n",
     "        \"description\": \"Updated scenario description\",\n",
     "        \"author\": \"Ernie\"\n",
-    "    }\n",
-    "})"
+    "    })\n",
+    "\n",
+    "\n",
+    "# You can also update the metadata attribute\n",
+    "scenario.update_metadata(\n",
+    "    metadata= {\n",
+    "        \"title\": \"New title\",\n",
+    "        \"extra_field\": \"Should merge nicely\",\n",
+    "        \"author\": \"Bert\"\n",
+    "    })\n",
+    "\n",
+    "#TODO: Because it's Jupyter it prints out the scenario json here - not standard stuff, I'm not sure how to supress it though"
    ]
   },
   {
@@ -197,18 +153,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "98ab2f5c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Modified inputs: 0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "scenario.remove_inputs([\"co_firing_biocoal_share\"])\n",
     "user_vals = scenario.user_values()\n",

--- a/examples/example.config.yml
+++ b/examples/example.config.yml
@@ -12,14 +12,11 @@ etm_api_token: your.token.here
 
 # Override the API base URL - here you can set which environment of the ETM you want to interact with.
 # Options include the default (pro), https://2025-01.engine.energytransitionmodel.com/api/v3 (a stable version) or
-# https://beta.engine.energytransitionmodel.com/api/v3	(the staging environment).
+# https://beta.engine.energytransitionmodel.com/api/v3	(the staging environment), or http://localhost:3000/api/v3
+# (your local environment).
 # For more information, see: https://docs.energytransitionmodel.com/api/intro#environments
 #
 BASE_URL: https://engine.energytransitionmodel.com/api/v3
-
-# Where your local model is run
-local_engine_url: http://localhost:3000/api/v3
-local_model_url: http://localhost:3001
 
 #TODO: Setup so the below is actually used
 # URLs of your proxy server addresses (replace the examples below by your own settings)

--- a/src/pyetm/models/scenario.py
+++ b/src/pyetm/models/scenario.py
@@ -94,11 +94,11 @@ class Scenario(Base):
             scenario.add_warning(w)
         return scenario
 
-    def update_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def update_metadata(self, **kwargs) -> Dict[str, Any]:
         """
         Update metadata for this scenario.
         """
-        result = UpdateMetadataRunner.run(BaseClient(), self, metadata)
+        result = UpdateMetadataRunner.run(BaseClient(), self, kwargs)
 
         if not result.success:
             raise ScenarioError(f"Could not update metadata: {result.errors}")
@@ -110,7 +110,6 @@ class Scenario(Base):
         # Update the current scenario object with the server response
         if result.data and "scenario" in result.data:
             scenario_data = result.data["scenario"]
-            # Update the current object's attributes with the server response
             for field, value in scenario_data.items():
                 if hasattr(self, field):
                     setattr(self, field, value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,27 @@
-'''
+"""
 Runs during test collection. You can also supply fixtures here that should be loaded
 before each test
-'''
+"""
+
 from pydantic import HttpUrl
 import os, sys, pytest
 
 # Ensure src/ is on sys.path before any imports of your app code
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-SRC  = os.path.join(ROOT, "src")
+SRC = os.path.join(ROOT, "src")
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
 # Set the ENV vars at import time so BaseClient picks up the test URL and token
-os.environ["BASE_URL"]       = "https://example.com/api"
-os.environ["ETM_API_TOKEN"]  = "etm_real.looking.token"
+os.environ["BASE_URL"] = "https://example.com/api"
+os.environ["ETM_API_TOKEN"] = "etm_real.looking.token"
+
 
 # Fixture to give back that same base URL for building expected mock URLs
 @pytest.fixture
 def api_url():
     return HttpUrl(os.getenv("BASE_URL"))
+
 
 # Mount the requests-mock adapter onto BaseClient.session so that
 # requests_mock.get(...) actually intercepts client.session.get(...)
@@ -30,112 +33,158 @@ def _mount_requests_mock(requests_mock, client):
     """
     adapter = getattr(requests_mock, "_adapter", None)
     if adapter and hasattr(client, "session") and hasattr(client.session, "session"):
-        client.session.session.mount("http://",  adapter)
+        client.session.session.mount("http://", adapter)
         client.session.session.mount("https://", adapter)
+
 
 # Lazy‐import BaseClient
 @pytest.fixture
 def client():
     from pyetm.clients.base_client import BaseClient
+
     return BaseClient()
+
 
 # Lazy‐import Scenario
 @pytest.fixture
 def scenario():
     from pyetm.models import Scenario
+
     return Scenario(id=999)
+
 
 @pytest.fixture
 def float_input_json():
     return {
-        "investment_costs_co2_ccs":
-            {
-                "min":-100.0,
-                "max":300.0,
-                "default":0.0,
-                "user": 10.0,
-                "unit":"%",
-                "disabled": False
-            }
+        "investment_costs_co2_ccs": {
+            "min": -100.0,
+            "max": 300.0,
+            "default": 0.0,
+            "user": 10.0,
+            "unit": "%",
+            "disabled": False,
+        }
     }
+
 
 @pytest.fixture
 def enum_input_json():
     return {
-        "settings_enable_storage_optimisation_households_flexibility_p2p_electricity":
-            {
-                "default":"default",
-                "unit":"enum",
-                "disabled": False,
-                "permitted_values":[
-                    "default","optimizing_storage","optimizing_storage_households"
-                ]
-            }
+        "settings_enable_storage_optimisation_households_flexibility_p2p_electricity": {
+            "default": "default",
+            "unit": "enum",
+            "disabled": False,
+            "permitted_values": [
+                "default",
+                "optimizing_storage",
+                "optimizing_storage_households",
+            ],
+        }
     }
+
 
 @pytest.fixture
 def bool_input_json():
     return {
-        "settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity":
-            {
-                "min":0.0,
-                "max":1.0,
-                "default":0.0,
-                "unit":"bool",
-                "disabled": False
-            }
+        "settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity": {
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.0,
+            "unit": "bool",
+            "disabled": False,
+        }
     }
+
 
 @pytest.fixture
 def disabled_input_json():
     return {
-        "external_coupling_energy_production_synthetic_kerosene_demand":
-            {
-                "min":0.0,
-                "max":10000.0,
-                "default":0.0,
-                "unit":"PJ",
-                "disabled": True,
-                "coupling_disabled": True,
-                "coupling_groups":["external_model_industry","ccus"]
-            }
+        "external_coupling_energy_production_synthetic_kerosene_demand": {
+            "min": 0.0,
+            "max": 10000.0,
+            "default": 0.0,
+            "unit": "PJ",
+            "disabled": True,
+            "coupling_disabled": True,
+            "coupling_groups": ["external_model_industry", "ccus"],
+        }
     }
 
+
 @pytest.fixture
-def input_collection_json(float_input_json, enum_input_json, bool_input_json, disabled_input_json):
+def input_collection_json(
+    float_input_json, enum_input_json, bool_input_json, disabled_input_json
+):
     return float_input_json | enum_input_json | bool_input_json | disabled_input_json
 
 
 @pytest.fixture
 def custom_curves_json():
-    return [{
-        "key": "interconnector_2_export_availability",
-        "type": "availability",
-        "display_group": "interconnectors",
-        "attached": True,
-        "overrides": ["electricity_interconnector_2_export_availability"],
-        "name": "interconnector_2_export_availability_curve",
-        "size": 78843,
-        "date": "2025-05-01T10:31:59.860Z",
-        "stats": {"length":8760,"min_at":3,"max_at":0}
-    },{
-        "key": "buildings_appliances",
-        "type": "profile",
-        "display_group": "buildings",
-        "attached": True,
-        "overrides": [],
-        "name": "buildings_appliances_curve",
-        "size": 78843,
-        "date": "2025-05-01T10:31:59.185Z",
-        "stats": {"length":8760,"min_at":4557,"max_at":2194}
-    }, {
-        "key": "weather/solar_pv_profile_1",
-        "type": "capacity_profile",
-        "display_group": "electricity_production",
-        "attached": True,
-        "overrides": ["flh_of_solar_pv_solar_radiation","flh_of_solar_pv_solar_radiation_user_curve"],
-        "name": "weather/solar_pv_profile_1_curve",
-        "size": 78843,
-        "date": "2025-05-01T10:32:02.014Z",
-        "stats":{"length":8760,"min_at":0,"max_at":3323,"full_load_hours":1000.0}
-    }]
+    return [
+        {
+            "key": "interconnector_2_export_availability",
+            "type": "availability",
+            "display_group": "interconnectors",
+            "attached": True,
+            "overrides": ["electricity_interconnector_2_export_availability"],
+            "name": "interconnector_2_export_availability_curve",
+            "size": 78843,
+            "date": "2025-05-01T10:31:59.860Z",
+            "stats": {"length": 8760, "min_at": 3, "max_at": 0},
+        },
+        {
+            "key": "buildings_appliances",
+            "type": "profile",
+            "display_group": "buildings",
+            "attached": True,
+            "overrides": [],
+            "name": "buildings_appliances_curve",
+            "size": 78843,
+            "date": "2025-05-01T10:31:59.185Z",
+            "stats": {"length": 8760, "min_at": 4557, "max_at": 2194},
+        },
+        {
+            "key": "weather/solar_pv_profile_1",
+            "type": "capacity_profile",
+            "display_group": "electricity_production",
+            "attached": True,
+            "overrides": [
+                "flh_of_solar_pv_solar_radiation",
+                "flh_of_solar_pv_solar_radiation_user_curve",
+            ],
+            "name": "weather/solar_pv_profile_1_curve",
+            "size": 78843,
+            "date": "2025-05-01T10:32:02.014Z",
+            "stats": {
+                "length": 8760,
+                "min_at": 0,
+                "max_at": 3323,
+                "full_load_hours": 1000.0,
+            },
+        },
+    ]
+
+
+# --- Service Result Fixtures --- #
+
+
+@pytest.fixture
+def ok_service_result():
+    """Factory fixture for creating successful ServiceResult objects"""
+    from pyetm.services.service_result import ServiceResult
+
+    def _make_result(data, errors=None):
+        return ServiceResult.ok(data=data, errors=errors or [])
+
+    return _make_result
+
+
+@pytest.fixture
+def fail_service_result():
+    """Factory fixture for creating failed ServiceResult objects"""
+    from pyetm.services.service_result import ServiceResult
+
+    def _make_result(errors):
+        return ServiceResult.fail(errors)
+
+    return _make_result

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -59,7 +59,7 @@ def sample_scenario():
 
     # Default mock methods that return empty lists/DataFrames
     scenario.custom_curves_series = Mock(return_value=[])
-    scenario.carrier_curves_series = Mock(return_value=[])
+    scenario.all_output_curves = Mock(return_value=[])
     scenario.queries_requested = Mock(return_value=False)
     scenario.results = Mock(return_value=pd.DataFrame())
 
@@ -83,7 +83,7 @@ def scenario_with_inputs():
 
     # Set up default mock methods
     scenario.custom_curves_series = Mock(return_value=[])
-    scenario.carrier_curves_series = Mock(return_value=[])
+    scenario.all_output_curves = Mock(return_value=[])
     scenario.queries_requested = Mock(return_value=False)
     scenario.results = Mock(return_value=pd.DataFrame())
 
@@ -111,14 +111,14 @@ def scenario_with_queries():
         },
         index=["total_costs", "co2_emissions", "energy_demand"],
     )
-    mock_results.index.name = 'gquery'
+    mock_results.index.name = "gquery"
 
-    scenario.results = Mock(return_value=mock_results.set_index('unit', append=True))
+    scenario.results = Mock(return_value=mock_results.set_index("unit", append=True))
     scenario.queries_requested = Mock(return_value=True)
 
     # Set up default mock methods
     scenario.custom_curves_series = Mock(return_value=[])
-    scenario.carrier_curves_series = Mock(return_value=[])
+    scenario.all_output_curves = Mock(return_value=[])
 
     # Mock sortables
     scenario.sortables = Mock()
@@ -142,7 +142,7 @@ def multiple_scenarios():
 
         # Set up default mock methods
         scenario.custom_curves_series = Mock(return_value=[])
-        scenario.carrier_curves_series = Mock(return_value=[])
+        scenario.all_output_curves = Mock(return_value=[])
         scenario.queries_requested = Mock(return_value=False)
         scenario.results = Mock(return_value=pd.DataFrame())
 
@@ -198,7 +198,13 @@ def bool_input_json():
 def disabled_input_json():
     """JSON data for a disabled input"""
     return {
-        "legacy_input": {"min": 0.0, "max": 100.0, "unit": 'euros', "default": 50.0, "disabled": True}
+        "legacy_input": {
+            "min": 0.0,
+            "max": 100.0,
+            "unit": "euros",
+            "default": 50.0,
+            "disabled": True,
+        }
     }
 
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -263,31 +263,6 @@ def custom_curves_json():
     ]
 
 
-# --- Service Result Fixtures --- #
-
-
-@pytest.fixture
-def ok_service_result():
-    """Factory fixture for creating successful ServiceResult objects"""
-    from pyetm.services.service_result import ServiceResult
-
-    def _make_result(data, errors=None):
-        return ServiceResult.ok(data=data, errors=errors or [])
-
-    return _make_result
-
-
-@pytest.fixture
-def fail_service_result():
-    """Factory fixture for creating failed ServiceResult objects"""
-    from pyetm.services.service_result import ServiceResult
-
-    def _make_result(errors):
-        return ServiceResult.fail(errors)
-
-    return _make_result
-
-
 # --- Test Model Fixtures --- #
 
 

--- a/tests/services/scenario_runners/test_update_metadata.py
+++ b/tests/services/scenario_runners/test_update_metadata.py
@@ -1,346 +1,377 @@
+import pytest
+from unittest.mock import Mock, patch
+from pyetm.services.service_result import ServiceResult
+from pyetm.clients.base_client import BaseClient
 from pyetm.services.scenario_runners.update_metadata import UpdateMetadataRunner
 
 
-def test_update_metadata_success(dummy_client, fake_response, dummy_scenario):
-    body = {"scenario": {"id": 1, "private": True}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(1)
-    metadata = {"private": True}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/1", {"json": {"scenario": metadata}})]
-
-
-def test_update_metadata_single_field(dummy_client, fake_response, dummy_scenario):
-    body = {"scenario": {"id": 2, "source": "pyetm"}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(2)
-    metadata = {"source": "pyetm"}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/2", {"json": {"scenario": metadata}})]
-
-
-def test_update_metadata_multiple_valid_fields(
+def test_update_metadata_runner_direct_fields_only(
     dummy_client, fake_response, dummy_scenario
 ):
-    body = {"scenario": {"id": 3}}
+    """Test updating only fields in META_KEYS."""
+    body = {"scenario": {"id": 123, "updated": True}}
     response = fake_response(ok=True, status_code=200, json_data=body)
     client = dummy_client(response, method="put")
-    scenario = dummy_scenario(3)
-    metadata = {
-        "private": False,
-        "keep_compatible": True,
-        "source": "api_update",
-    }
+    scenario = dummy_scenario(123)
+    scenario.metadata = {"existing": "value"}
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/3", {"json": {"scenario": metadata}})]
+    metadata = {"end_year": 2050, "private": True, "keep_compatible": False}
 
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data=body, errors=[])
+        mock_request.return_value = mock_result
 
-def test_update_metadata_auto_nests_unrecognized_fields(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test that unrecognized fields are automatically nested under 'metadata'"""
-    body = {"scenario": {"id": 4}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(4)
-    metadata = {
-        "private": True,  # Direct field
-        "title": "My Test",  # Should be nested
-        "description": "A test scenario",  # Should be nested
-        "author": "John Doe",  # Should be nested
-    }
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 1
-    assert (
-        "Field 'title' cannot be updated directly and has been added to nested metadata instead"
-        in result.errors
-    )
-
-    # Should auto-nest unrecognized fields
-    expected_payload = {
-        "scenario": {
-            "private": True,
-            "metadata": {
-                "title": "My Test",
-                "description": "A test scenario",
-                "author": "John Doe",
-            },
+        expected_payload = {
+            "scenario": {
+                "end_year": 2050,
+                "private": True,
+                "keep_compatible": False,
+                "metadata": {"existing": "value"},
+            }
         }
-    }
-    assert client.calls == [("/scenarios/4", {"json": expected_payload})]
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+        assert result == mock_result
 
 
-def test_update_metadata_filters_and_nests_fields(
+def test_update_metadata_runner_nested_metadata_only(
     dummy_client, fake_response, dummy_scenario
 ):
-    """Test mixed direct fields and fields that should be auto-nested"""
-    body = {"scenario": {"id": 5}}
+    """Test updating only custom fields (nested in metadata)."""
+    body = {"scenario": {"id": 123, "updated": True}}
     response = fake_response(ok=True, status_code=200, json_data=body)
     client = dummy_client(response, method="put")
-    scenario = dummy_scenario(5)
-    metadata = {
-        "private": True,  # Direct field
-        "keep_compatible": True,  # Direct field
-        "end_year": 2050,  # Direct field (settable)
-        "area_code": "nl",  # Should be nested with warning (unsettable)
-        "title": "Test Scenario",  # Should be nested with warning (unsettable)
-    }
+    scenario = dummy_scenario(123)
+    scenario.metadata = {"existing": "value"}
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 2
-    expected_warnings = [
-        "Field 'area_code' cannot be updated directly and has been added to nested metadata instead",
-        "Field 'title' cannot be updated directly and has been added to nested metadata instead",
-    ]
-    for warning in expected_warnings:
-        assert warning in result.errors
+    metadata = {"custom_field": "custom_value", "another_field": 42}
 
-    expected_payload = {
-        "scenario": {
-            "private": True,
-            "keep_compatible": True,
-            "end_year": 2050,
-            "metadata": {
-                "area_code": "nl",
-                "title": "Test Scenario",
-            },
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data=body, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "metadata": {
+                    "existing": "value",
+                    "custom_field": "custom_value",
+                    "another_field": 42,
+                }
+            }
         }
-    }
-    assert client.calls == [("/scenarios/5", {"json": expected_payload})]
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
 
 
-def test_update_metadata_empty_metadata(dummy_client, fake_response, dummy_scenario):
-    body = {"scenario": {"id": 6}}
+def test_update_metadata_runner_mixed_fields(
+    dummy_client, fake_response, dummy_scenario
+):
+    """Test updating both direct and nested fields."""
+    body = {"scenario": {"id": 123, "updated": True}}
     response = fake_response(ok=True, status_code=200, json_data=body)
     client = dummy_client(response, method="put")
-    scenario = dummy_scenario(6)
+    scenario = dummy_scenario(123)
+    scenario.metadata = {"existing": "value"}
+
+    metadata = {"end_year": 2050, "private": True, "custom_field": "custom_value"}
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data=body, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "end_year": 2050,
+                "private": True,
+                "metadata": {"existing": "value", "custom_field": "custom_value"},
+            }
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_unsettable_keys_generate_warnings():
+    """Test that unsettable keys generate warnings and are nested."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {"existing": "value"}
+
+    metadata = {
+        "id": 456,  # Unsettable
+        "title": "New Title",  # Unsettable
+        "end_year": 2050,  # Settable
+    }
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "end_year": 2050,
+                "metadata": {"existing": "value", "id": 456, "title": "New Title"},
+            }
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_direct_metadata_field_priority():
+    """Test that direct 'metadata' field has highest priority."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {"existing": "value"}
+
+    metadata = {
+        "custom_field": "will_be_overridden",
+        "metadata": {"custom_field": "priority_value", "new_field": "new_value"},
+    }
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "metadata": {
+                    "existing": "value",
+                    "custom_field": "priority_value",  # Direct metadata wins
+                    "new_field": "new_value",
+                }
+            }
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_scenario_without_existing_metadata():
+    """Test updating scenario that has no existing metadata."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = None  # No existing metadata
+
+    metadata = {"custom_field": "value", "end_year": 2050}
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {"end_year": 2050, "metadata": {"custom_field": "value"}}
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_scenario_with_non_dict_metadata():
+    """Test updating scenario with non-dict metadata attribute."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = "not_a_dict"  # Invalid metadata type
+
+    metadata = {"custom_field": "value"}
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {"scenario": {"metadata": {"custom_field": "value"}}}
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_scenario_without_metadata_attribute():
+    """Test updating scenario that doesn't have metadata attribute."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    # Don't set metadata attribute at all
+
+    metadata = {"custom_field": "value"}
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        # Mock hasattr to return False for metadata
+        with patch("builtins.hasattr", return_value=False):
+            result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {"scenario": {"metadata": {"custom_field": "value"}}}
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_empty_metadata():
+    """Test running with empty metadata dictionary."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {"existing": "value"}
+
     metadata = {}
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/6", {"json": {"scenario": {}}})]
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        # Should still send existing metadata
+        expected_payload = {"scenario": {"metadata": {"existing": "value"}}}
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
 
 
-def test_update_metadata_with_nested_metadata_field(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test when user explicitly provides a metadata field"""
-    body = {"scenario": {"id": 7}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(7)
-    metadata = {
-        "metadata": {
-            "description": "Updated scenario",
-            "author": "bert",
-            "tags": ["test", "pyetm"],
-        }
-    }
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/7", {"json": {"scenario": metadata}})]
-
-
-def test_update_metadata_merges_explicit_and_auto_nested_metadata(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test merging when user provides both explicit metadata and fields that should be auto-nested"""
-    body = {"scenario": {"id": 8}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(8)
-    metadata = {
-        "private": True,
-        "metadata": {"description": "Existing metadata", "tags": ["existing"]},
-        "title": "Auto-nested title",
-        "author": "Auto-nested author",
-    }
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 1
-    assert (
-        "Field 'title' cannot be updated directly and has been added to nested metadata instead"
-        in result.errors
-    )
-
-    expected_payload = {
-        "scenario": {
-            "private": True,
-            "metadata": {
-                "description": "Existing metadata",
-                "tags": ["existing"],
-                "title": "Auto-nested title",
-                "author": "Auto-nested author",
-            },
-        }
-    }
-    assert client.calls == [("/scenarios/8", {"json": expected_payload})]
-
-
-def test_update_metadata_replaces_non_dict_metadata(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test that non-dict metadata field gets replaced when auto-nesting occurs"""
-    body = {"scenario": {"id": 9}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(9)
-    metadata = {
-        "metadata": "not a dict",
-        "title": "New title",
-        "author": "New author",
-    }
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 1
-    assert (
-        "Field 'title' cannot be updated directly and has been added to nested metadata instead"
-        in result.errors
-    )
-
-    expected_payload = {
-        "scenario": {"metadata": {"title": "New title", "author": "New author"}}
-    }
-    assert client.calls == [("/scenarios/9", {"json": expected_payload})]
-
-
-def test_update_metadata_with_kwargs(dummy_client, fake_response, dummy_scenario):
-    body = {"scenario": {"id": 10}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(10)
-    metadata = {"title": "Updated Scenario"}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata, timeout=30)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 1
-    assert (
-        "Field 'title' cannot be updated directly and has been added to nested metadata instead"
-        in result.errors
-    )
-
-    expected_payload = {"scenario": {"metadata": {"title": "Updated Scenario"}}}
-    assert client.calls == [("/scenarios/10", {"json": expected_payload})]
-
-
-def test_update_metadata_http_failure_422(dummy_client, fake_response, dummy_scenario):
-    response = fake_response(ok=False, status_code=422, text="Validation Error")
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(11)
-    metadata = {"private": "invalid_value"}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is False
-    assert result.data is None
-    assert result.errors == ["422: Validation Error"]
-
-
-def test_update_metadata_http_failure_404(dummy_client, fake_response, dummy_scenario):
-    response = fake_response(ok=False, status_code=404, text="Scenario not found")
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(999)
-    metadata = {"private": True}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is False
-    assert result.data is None
-    assert result.errors == ["404: Scenario not found"]
-
-
-def test_update_metadata_connection_error(dummy_client, dummy_scenario):
-    client = dummy_client(ConnectionError("Connection failed"), method="put")
-    scenario = dummy_scenario(12)
-    metadata = {"private": True}
-
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is False
-    assert result.data is None
-    assert any("Connection failed" in err for err in result.errors)
-
-
-def test_update_metadata_all_valid_direct_fields(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test updating all valid direct META_KEYS fields"""
-    body = {"scenario": {"id": 13}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(13)
+def test_update_metadata_runner_all_meta_keys():
+    """Test updating with all possible META_KEYS."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {"existing": "value"}
 
     metadata = {
         "keep_compatible": True,
         "private": False,
-        "source": "pyetm",
-        "metadata": {"test": "data", "author": "test_user"},
+        "source": "test_source",
+        "metadata": {"nested": "value"},
+        "end_year": 2060,
     }
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert result.errors == []
-    assert client.calls == [("/scenarios/13", {"json": {"scenario": metadata}})]
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "keep_compatible": True,
+                "private": False,
+                "source": "test_source",
+                "end_year": 2060,
+                "metadata": {"existing": "value", "nested": "value"},
+            }
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
 
 
-def test_update_metadata_only_nested_fields(
-    dummy_client, fake_response, dummy_scenario
-):
-    """Test updating only fields that should be auto-nested"""
-    body = {"scenario": {"id": 14}}
-    response = fake_response(ok=True, status_code=200, json_data=body)
-    client = dummy_client(response, method="put")
-    scenario = dummy_scenario(14)
+def test_update_metadata_runner_meta_keys_constants():
+    """Test that META_KEYS and UNSETTABLE_META_KEYS are properly defined."""
+    expected_meta_keys = [
+        "keep_compatible",
+        "private",
+        "source",
+        "metadata",
+        "end_year",
+    ]
+
+    expected_unsettable_keys = [
+        "id",
+        "created_at",
+        "updated_at",
+        "area_code",
+        "title",
+        "start_year",
+        "scaling",
+        "template",
+        "url",
+    ]
+
+    assert UpdateMetadataRunner.META_KEYS == expected_meta_keys
+    assert UpdateMetadataRunner.UNSETTABLE_META_KEYS == expected_unsettable_keys
+
+
+def test_update_metadata_runner_non_dict_direct_metadata_field():
+    """Test handling when direct 'metadata' field is not a dict."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {"existing": "value"}
 
     metadata = {
-        "title": "Test Scenario",
-        "description": "A test",
-        "author": "John Doe",
-        "end_year": 2050,
+        "custom_field": "value",
+        "metadata": "not_a_dict",  # Invalid metadata type
     }
 
-    result = UpdateMetadataRunner.run(client, scenario, metadata)
-    assert result.success is True
-    assert result.data == body
-    assert len(result.errors) == 1
-    expected_warning = "Field 'title' cannot be updated directly and has been added to nested metadata instead"
-    assert expected_warning in result.errors
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
 
-    expected_payload = {
-        "scenario": {
-            "end_year": 2050,
-            "metadata": {
-                "title": "Test Scenario",
-                "description": "A test",
-                "author": "John Doe",
-            },
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        # Should still include existing metadata and custom_field, but skip invalid direct metadata
+        expected_payload = {
+            "scenario": {"metadata": {"existing": "value", "custom_field": "value"}}
         }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )
+
+
+def test_update_metadata_runner_preserves_existing_metadata_when_merging():
+    """Test that existing metadata is preserved when adding new fields."""
+    client = Mock(spec=BaseClient)
+    scenario = Mock()
+    scenario.id = 123
+    scenario.metadata = {
+        "author": "original_author",
+        "description": "original_description",
+        "tags": ["original"],
     }
-    assert client.calls == [("/scenarios/14", {"json": expected_payload})]
+
+    metadata = {
+        "description": "updated_description",  # Should override
+        "new_field": "new_value",  # Should be added
+        "end_year": 2050,  # Direct field
+    }
+
+    with patch.object(UpdateMetadataRunner, "_make_request") as mock_request:
+        mock_result = ServiceResult(success=True, data={"updated": True}, errors=[])
+        mock_request.return_value = mock_result
+
+        result = UpdateMetadataRunner.run(client, scenario, metadata)
+
+        expected_payload = {
+            "scenario": {
+                "end_year": 2050,
+                "metadata": {
+                    "author": "original_author",  # Preserved
+                    "description": "updated_description",  # Updated
+                    "tags": ["original"],  # Preserved
+                    "new_field": "new_value",  # Added
+                },
+            }
+        }
+        mock_request.assert_called_once_with(
+            client=client, method="put", path="/scenarios/123", payload=expected_payload
+        )


### PR DESCRIPTION
Fixes for the metadata flow (using kwargs and merging nested metadata) and updates to the relevant tests.

Also updates to some other tests and catching extra fallout from renaming to output_curves