### PR TITLE
Simpler to_dataframe for inputs

### DIFF
--- a/examples/example_helpers.py
+++ b/examples/example_helpers.py
@@ -52,7 +52,7 @@ def setup_notebook(debug=False):
         except Exception:
             pass
 
-        def show(obj, *, index=False):
+        def show(obj):
             """Pretty-display DataFrames/Series (HTML) or fall back to normal display."""
 
             if isinstance(obj, (pd.DataFrame, pd.Series)):
@@ -79,13 +79,7 @@ def setup_notebook(debug=False):
                         )
                         return
 
-                    styler = obj.style
-                    styler = styler.format(precision=3)
-                    if not index and isinstance(obj, pd.DataFrame):
-                        try:
-                            styler = styler.hide(axis="index")
-                        except Exception:
-                            pass
+                    styler = obj.style.format(precision=3)
                     display(styler)
                 except Exception:
                     display(obj)

--- a/examples/notebook_for_scenarios.ipynb
+++ b/examples/notebook_for_scenarios.ipynb
@@ -65,9 +65,17 @@
     "from pyetm.models.scenario_packer import ScenarioPacker\n",
     "\n",
     "packer = ScenarioPacker()\n",
-    "packer.add(*scenarios)\n",
-    "\n",
-    "packer.inputs(columns=[\"user\", \"default\", \"min\", \"max\"]).head(15)"
+    "packer.add(*scenarios)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40ecc2e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "packer.inputs(columns=[\"user\", \"default\", \"min\", \"max\", \"permitted_values\"]).head(15)"
    ]
   },
   {
@@ -107,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The flag include_input_details includes min max and default for inputs - this is a separate sheet to include_inputs\n",
+    "# The flag include_input_details includes min max and default for inputs in a separate sheet INPUT_DETAILS\n",
     "packer.to_excel(include_inputs=True, include_input_details=True, include_sortables=True, path=\"../examples/outputs/scenarios.xlsx\")"
    ]
   }

--- a/src/pyetm/models/inputs.py
+++ b/src/pyetm/models/inputs.py
@@ -78,11 +78,43 @@ class BoolInput(Input):
     @field_validator("user", mode="after")
     @classmethod
     def is_bool_float(cls, value: Optional[float]) -> Optional[float]:
-        if value == 1.0 or value == 0.0 or value is None:
+        if pd.isna(value) or value in [1.0, 0.0]:
             return value
         raise ValueError(
             f"{value} should be 1.0 or 0.0 representing True/False, or On/Off"
         )
+
+    @field_validator("user", mode="before")
+    @classmethod
+    def coerce_bool(cls, value):
+        if value is None:
+            return None
+
+        truth_map = {
+            "true": 1.0,
+            "t": 1.0,
+            "1": 1.0,
+            "yes": 1.0,
+            "y": 1.0,
+            "on": 1.0,
+            "false": 0.0,
+            "f": 0.0,
+            "0": 0.0,
+            "no": 0.0,
+            "n": 0.0,
+            "off": 0.0,
+        }
+
+        if isinstance(value, str):
+            return truth_map.get(value.strip().lower(), value)
+
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+
+        if isinstance(value, (int, float)):
+            return 1.0 if value != 0 else 0.0
+
+        return value
 
 
 class EnumInput(Input):
@@ -101,7 +133,7 @@ class EnumInput(Input):
 
     @model_validator(mode="after")
     def check_permitted(self) -> EnumInput:
-        if self.user is None or self.user in self.permitted_values:
+        if pd.isna(self.user) or self.user in self.permitted_values:
             return self
         self._raise_exception_on_loc(
             "ValueError",
@@ -109,6 +141,13 @@ class EnumInput(Input):
             loc="user",
             msg=f"Value error, {self.user} should be in {self.permitted_values}",
         )
+
+    @field_validator("user", mode="before")
+    @classmethod
+    def coerce_enum(cls, value):
+        if pd.isna(value):
+            return None
+        return pd.Series([value]).astype(str).str.strip().iloc[0]
 
 
 class FloatInput(Input):
@@ -141,6 +180,23 @@ class FloatInput(Input):
             loc="user",
             msg=f"Value error, {self.user} should be between {self.min} and {self.max}",
         )
+
+    @field_validator("user", mode="before")
+    @classmethod
+    def coerce_float(cls, value):
+        if pd.isna(value):
+            return None
+        try:
+            if isinstance(value, str):
+                return pd.to_numeric(
+                    pd.Series([value]).str.strip(), errors="raise"
+                ).iloc[0]
+            elif isinstance(value, (int, float)):
+                return pd.Series([value], dtype=float).iloc[0]
+        except (ValueError, pd.errors.ParserError):
+            pass
+
+        return value
 
 
 class Inputs(Base):

--- a/src/pyetm/models/inputs.py
+++ b/src/pyetm/models/inputs.py
@@ -199,17 +199,20 @@ class Inputs(Base):
         if not isinstance(columns, list):
             columns = [columns]
         columns = ["unit"] + columns
-
-        df = pd.DataFrame.from_dict(
-            {
-                input.key: [getattr(input, key, None) for key in columns]
-                for input in self.inputs
-            },
-            orient="index",
-            columns=columns,
-        )
-        df.index.name = "input"
-        return df.set_index("unit", append=True)
+        try:
+            df = pd.DataFrame.from_dict(
+                {
+                    input.key: [getattr(input, key, None) for key in columns]
+                    for input in self.inputs
+                },
+                orient="index",
+                columns=columns,
+            )
+            df.index.name = "input"
+            return df.set_index("unit", append=True)
+        except Exception as e:
+            self.add_warning("_to_dataframe", f"Failed to create DataFrame: {e}")
+            return pd.DataFrame()
 
     @classmethod
     def from_json(cls, data) -> Inputs:

--- a/src/pyetm/models/packables/inputs_pack.py
+++ b/src/pyetm/models/packables/inputs_pack.py
@@ -63,66 +63,6 @@ class InputsPack(Packable):
 
         return None
 
-    def _extract_input_values(self, scenario, field_name: str) -> Dict[str, Any]:
-        """Extract input values for a specific field from a scenario."""
-        values = self._extract_from_input_objects(scenario, field_name)
-        if values:
-            return values
-
-        return self._extract_from_dataframe(scenario, field_name)
-
-    def _extract_from_input_objects(self, scenario, field_name: str) -> Dict[str, Any]:
-        """Extract values by iterating through scenario input objects."""
-        try:
-            values = {}
-            for input_obj in scenario.inputs:
-                key = getattr(input_obj, "key", None)
-                if key is None:
-                    continue
-
-                value = getattr(input_obj, field_name, None)
-                values[str(key)] = value
-
-            return values if values else {}
-        except Exception:
-            return {}
-
-    def _extract_from_dataframe(self, scenario, field_name: str) -> Dict[str, Any]:
-        """Extract values from scenario inputs DataFrame."""
-        try:
-            df = scenario.inputs.to_dataframe(columns=field_name)
-        except Exception:
-            return {}
-
-        if df is None or getattr(df, "empty", False):
-            return {}
-
-        # Handle MultiIndex (drop 'unit' level if present)
-        df = self._normalize_dataframe_index(df)
-        series = self._dataframe_to_series(df, field_name)
-        if series is None:
-            return {}
-
-        series.index = series.index.map(str)
-        return series.to_dict()
-
-    def _normalize_dataframe_index(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Remove 'unit' level from MultiIndex if present."""
-        if isinstance(df.index, pd.MultiIndex) and "unit" in (df.index.names or []):
-            df = df.copy()
-            df.index = df.index.droplevel("unit")
-        return df
-
-    def _dataframe_to_series(self, df: pd.DataFrame, field_name: str) -> pd.Series:
-        """Convert DataFrame to Series, selecting appropriate column."""
-        if isinstance(df, pd.Series):
-            return df
-        columns_lower = {str(col).lower(): col for col in df.columns}
-        for candidate in (field_name, "user", "value", "default"):
-            if candidate in columns_lower:
-                return df[columns_lower[candidate]]
-        return df.iloc[:, 0]
-
     def to_dataframe(
         self,
         columns: str | List[str] = "user",
@@ -133,43 +73,35 @@ class InputsPack(Packable):
         if not self.scenarios:
             return pd.DataFrame()
 
-        # Normalize requested columns
-        base_cols: List[str]
-        if isinstance(columns, list):
-            base_cols = [c for c in columns if c]
+        if isinstance(columns, str):
+            cols = [columns] if columns else []
         else:
-            base_cols = [str(columns)] if columns else ["user"]
-        if not base_cols:
-            base_cols = ["user"]
+            cols = [c for c in columns if c]
+        if "user" in cols:
+            cols.remove("user")
+        cols.insert(0, "user")
 
-        if "user" not in base_cols:
-            base_cols.insert(0, "user")
-
-        if include_defaults and "default" not in base_cols:
-            base_cols.append("default")
+        if include_defaults:
+            for col in ("default", "permitted_values"):
+                if col not in cols:
+                    cols.append(col)
         if include_min_max:
-            for extra in ("min", "max"):
-                if extra not in base_cols:
-                    base_cols.append(extra)
+            for col in ("min", "max"):
+                if col not in cols:
+                    cols.append(col)
 
-        frames: List[pd.DataFrame] = []
-        labels: List[Any] = []
+        frames, labels = [], []
         for scenario in self.scenarios:
-            try:
-                df = scenario.inputs.to_dataframe(columns=base_cols)
-            except Exception:
-                continue
-            if df is None or getattr(df, "empty", False):
-                continue
+            df = scenario.inputs.to_dataframe(columns=cols)
+            if df is not None and not df.empty:
+                frames.append(df)
+                labels.append(self._get_scenario_display_key(scenario))
 
-            frames.append(df)
-            labels.append(self._get_scenario_display_key(scenario))
-
-        if not frames:
-            return pd.DataFrame()
-
-        merged = pd.concat(frames, axis=1, keys=labels, names=["scenario", "field"])
-        return merged
+        return (
+            pd.concat(frames, axis=1, keys=labels, names=["scenario", "field"])
+            if frames
+            else pd.DataFrame()
+        )
 
     def _to_dataframe(self, columns="user", **kwargs):
         return self.to_dataframe(columns=columns)
@@ -183,17 +115,16 @@ class InputsPack(Packable):
     ):
         """Add inputs sheet with proper field handling. Optionally override sheet name."""
         name = sheet_name if sheet_name else self.sheet_name
-        try:
-            df = self.to_dataframe(
-                include_defaults=include_defaults, include_min_max=include_min_max
+        df = self.to_dataframe(
+            include_defaults=include_defaults, include_min_max=include_min_max
+        )
+        if df is not None and not df.empty:
+            df = df.map(
+                lambda v: (
+                    ", ".join(map(str, v)) if isinstance(v, (list, tuple, set)) else v
+                )
             )
-            if df is not None and not df.empty:
-                self._add_dataframe_to_workbook(workbook, name, df)
-        except Exception as e:
-            logger.warning("Failed to build inputs DataFrame: %s", e)
-            df = self.to_dataframe()
-            if df is not None and not df.empty:
-                self._add_dataframe_to_workbook(workbook, name, df)
+            self._add_dataframe_to_workbook(workbook, name, df)
 
     def import_from_excel(
         self,
@@ -255,16 +186,18 @@ class InputsPack(Packable):
                 column_data = data_df[column_name]
 
                 # Filter out blank values
-                updates = {
-                    key: value
-                    for key, value in column_data.items()
-                    if not self._is_blank_value(value)
-                }
+                non_blank_mask = (
+                    ~column_data.isin([None, "", "nan"]) & column_data.notna()
+                )
+                raw_updates = column_data[non_blank_mask].to_dict()
 
-                if not updates:
+                if not raw_updates:
                     continue
+
+                converted_updates = self._convert_import_values(scenario, raw_updates)
+
                 try:
-                    scenario.update_user_values(updates)
+                    scenario.update_user_values(converted_updates)
                 except Exception as e:
                     logger.warning(
                         "Failed updating inputs for scenario '%s' from column '%s': %s",
@@ -278,12 +211,58 @@ class InputsPack(Packable):
         except Exception as e:
             logger.warning("Failed to parse simplified SLIDER_SETTINGS sheet: %s", e)
 
-    def _is_blank_value(self, value: Any) -> bool:
-        """Check if a value should be considered blank/empty."""
-        if value is None:
-            return True
-        if isinstance(value, float) and pd.isna(value):
-            return True
-        if isinstance(value, str) and value.strip().lower() in {"", "nan"}:
-            return True
-        return False
+    def _convert_import_values(self, scenario, raw_updates: dict) -> dict:
+        """Convert imported values using Input model validation logic."""
+        converted = {}
+
+        for key, value in raw_updates.items():
+            input_obj = scenario.inputs.get_input_by_key(key)
+
+            if input_obj is None:
+                converted[key] = value
+                continue
+
+            try:
+                warnings = input_obj.is_valid_update(value)
+                if len(warnings) == 0:
+                    converted[key] = value
+                else:
+                    # Try to convert based on input type
+                    converted_value = self._try_convert_value(input_obj, value)
+                    converted[key] = converted_value
+
+            except Exception as e:
+                logger.warning(f"Error processing input '{key}': {e}")
+                converted[key] = value
+
+        return converted
+
+    def _try_convert_value(self, input_obj, value):
+        """Try to convert value based on input type"""
+        unit = getattr(input_obj, "unit", "")
+
+        if unit == "bool":
+            if isinstance(value, str):
+                value_lower = value.lower().strip()
+                if value_lower in ("true", "t", "1", "yes", "y", "on"):
+                    return 1.0
+                elif value_lower in ("false", "f", "0", "no", "n", "off"):
+                    return 0.0
+            elif isinstance(value, bool):
+                return 1.0 if value else 0.0
+            elif isinstance(value, (int, float)):
+                return 1.0 if value != 0 else 0.0
+
+        elif unit == "enum":
+            return str(value).strip()
+
+        else:
+            if isinstance(value, str):
+                try:
+                    return float(value.strip())
+                except ValueError:
+                    pass
+            elif isinstance(value, (int, float)):
+                return float(value)
+
+        return value

--- a/src/pyetm/models/packables/inputs_pack.py
+++ b/src/pyetm/models/packables/inputs_pack.py
@@ -2,6 +2,7 @@ import logging
 from typing import ClassVar, Dict, Any, List, Optional
 from openpyxl import Workbook
 import pandas as pd
+import numpy as np
 from pyetm.models.packables.packable import Packable
 from pyetm.utils import excel_utils
 
@@ -173,7 +174,9 @@ class InputsPack(Packable):
 
             # Process each scenario column
             scenario_columns = [col for col in data_df.columns if col != input_column]
-
+            data_df[scenario_columns] = data_df[scenario_columns].replace(
+                {"": np.nan, "nan": np.nan}
+            )
             for column_name in scenario_columns:
                 scenario = self.resolve_scenario(column_name)
                 if scenario is None:
@@ -183,21 +186,12 @@ class InputsPack(Packable):
                     )
                     continue
 
-                column_data = data_df[column_name]
-
-                # Filter out blank values
-                non_blank_mask = (
-                    ~column_data.isin([None, "", "nan"]) & column_data.notna()
-                )
-                raw_updates = column_data[non_blank_mask].to_dict()
-
+                raw_updates = data_df[column_name].dropna().to_dict()
                 if not raw_updates:
                     continue
 
-                converted_updates = self._convert_import_values(scenario, raw_updates)
-
                 try:
-                    scenario.update_user_values(converted_updates)
+                    scenario.update_user_values(raw_updates)
                 except Exception as e:
                     logger.warning(
                         "Failed updating inputs for scenario '%s' from column '%s': %s",
@@ -210,59 +204,3 @@ class InputsPack(Packable):
 
         except Exception as e:
             logger.warning("Failed to parse simplified SLIDER_SETTINGS sheet: %s", e)
-
-    def _convert_import_values(self, scenario, raw_updates: dict) -> dict:
-        """Convert imported values using Input model validation logic."""
-        converted = {}
-
-        for key, value in raw_updates.items():
-            input_obj = scenario.inputs.get_input_by_key(key)
-
-            if input_obj is None:
-                converted[key] = value
-                continue
-
-            try:
-                warnings = input_obj.is_valid_update(value)
-                if len(warnings) == 0:
-                    converted[key] = value
-                else:
-                    # Try to convert based on input type
-                    converted_value = self._try_convert_value(input_obj, value)
-                    converted[key] = converted_value
-
-            except Exception as e:
-                logger.warning(f"Error processing input '{key}': {e}")
-                converted[key] = value
-
-        return converted
-
-    def _try_convert_value(self, input_obj, value):
-        """Try to convert value based on input type"""
-        unit = getattr(input_obj, "unit", "")
-
-        if unit == "bool":
-            if isinstance(value, str):
-                value_lower = value.lower().strip()
-                if value_lower in ("true", "t", "1", "yes", "y", "on"):
-                    return 1.0
-                elif value_lower in ("false", "f", "0", "no", "n", "off"):
-                    return 0.0
-            elif isinstance(value, bool):
-                return 1.0 if value else 0.0
-            elif isinstance(value, (int, float)):
-                return 1.0 if value != 0 else 0.0
-
-        elif unit == "enum":
-            return str(value).strip()
-
-        else:
-            if isinstance(value, str):
-                try:
-                    return float(value.strip())
-                except ValueError:
-                    pass
-            elif isinstance(value, (int, float)):
-                return float(value)
-
-        return value

--- a/src/pyetm/utils/excel_utils.py
+++ b/src/pyetm/utils/excel_utils.py
@@ -9,9 +9,8 @@ from xlsxwriter.workbook import Workbook
 from xlsxwriter.worksheet import Worksheet
 from pyetm.models.export_config import ExportConfig
 
+
 # Export config resolution
-
-
 class ExportConfigResolver:
     @staticmethod
     def extract_from_main_sheet(
@@ -187,8 +186,6 @@ class ExportConfigResolver:
 
 
 # Excel writing
-
-
 def handle_numeric_value(
     worksheet: Worksheet,
     row: int,
@@ -523,8 +520,6 @@ def add_series(
 
 
 # Dataframe prep and sanitization
-
-
 def sanitize_dataframe_for_excel(df: pd.DataFrame) -> pd.DataFrame:
     """Convert DataFrame to Excel-compatible format."""
     if df is None or df.empty:
@@ -556,6 +551,13 @@ def sanitize_excel_value(value: Any) -> Any:
             return str(value)
         except Exception:
             return ""
+
+    # Handle lists by converting to comma-separated string
+    if isinstance(value, (list, tuple, set)):
+        try:
+            return ", ".join(str(item) for item in value)
+        except Exception:
+            return str(value)
 
     # Generic fallback
     try:

--- a/tests/models/packables/test_inputs_pack.py
+++ b/tests/models/packables/test_inputs_pack.py
@@ -163,95 +163,6 @@ def test_resolve_scenario_returns_none_for_none():
     assert result is None
 
 
-def test_extract_input_values_from_objects():
-    inputs_data = {
-        "input1": {"user": 10, "default": 5},
-        "input2": {"user": 20, "default": 15},
-    }
-    scenario = make_scenario(inputs_data=inputs_data)
-
-    pack = InputsPack()
-
-    result = pack._extract_input_values(scenario, "user")
-
-    assert result == {"input1": 10, "input2": 20}
-
-
-def test_extract_input_values_from_dataframe():
-    scenario = make_scenario()
-    # Make input objects iteration fail to fall back to dataframe
-    scenario.inputs.__iter__.side_effect = Exception("No objects")
-
-    # Set up dataframe fallback
-    df = pd.DataFrame({"user": [10, 20]}, index=["input1", "input2"])
-    scenario.inputs.to_dataframe = Mock(return_value=df)
-
-    pack = InputsPack()
-
-    result = pack._extract_input_values(scenario, "user")
-
-    assert result == {"input1": 10, "input2": 20}
-
-
-def test_extract_from_input_objects_handles_missing_key():
-    input_obj = Mock()
-    input_obj.key = None  # Missing key
-    scenario = Mock()
-    scenario.inputs = [input_obj]
-
-    pack = InputsPack()
-
-    result = pack._extract_from_input_objects(scenario, "user")
-
-    assert result == {}
-
-
-def test_extract_from_dataframe_handles_exception():
-    scenario = Mock()
-    scenario.inputs.to_dataframe.side_effect = Exception("DataFrame error")
-
-    pack = InputsPack()
-
-    result = pack._extract_from_dataframe(scenario, "user")
-
-    assert result == {}
-
-
-def test_normalize_dataframe_index_removes_unit_level():
-    # Create MultiIndex with 'unit' level
-    index = pd.MultiIndex.from_tuples(
-        [("input1", "MW"), ("input2", "GW")], names=["key", "unit"]
-    )
-    df = pd.DataFrame({"user": [10, 20]}, index=index)
-
-    pack = InputsPack()
-
-    result = pack._normalize_dataframe_index(df)
-
-    assert not isinstance(result.index, pd.MultiIndex)
-    assert list(result.index) == ["input1", "input2"]
-
-
-def test_dataframe_to_series_returns_series():
-    series = pd.Series([10, 20], index=["input1", "input2"])
-
-    pack = InputsPack()
-
-    result = pack._dataframe_to_series(series, "user")
-
-    assert result is series
-
-
-def test_dataframe_to_series_selects_column():
-    df = pd.DataFrame({"user": [10, 20], "default": [5, 15]})
-
-    pack = InputsPack()
-
-    result = pack._dataframe_to_series(df, "user")
-
-    pd.testing.assert_series_equal(result, df["user"])
-
-
 def test_to_dataframe_with_scenarios():
     inputs_data1 = {"input1": {"user": 10}, "input2": {"user": 20}}
     inputs_data2 = {"input1": {"user": 15}, "input2": {"user": 25}}
@@ -300,18 +211,6 @@ def test_to_dataframe_with_include_min_max():
 
     assert "min" in df.columns.get_level_values("field")
     assert "max" in df.columns.get_level_values("field")
-
-
-def test_to_dataframe_handles_exception(caplog):
-    s = make_scenario()
-    s.inputs.to_dataframe.side_effect = RuntimeError("DataFrame error")
-
-    pack = InputsPack()
-    pack.add(s)
-
-    df = pack.to_dataframe()
-
-    assert df.empty
 
 
 def test_from_dataframe_handles_missing_scenario(caplog):

--- a/tests/models/test_inputs.py
+++ b/tests/models/test_inputs.py
@@ -122,26 +122,18 @@ def test_bool_input():
     input_obj.user = 0.0
     assert input_obj.user == 0.0
 
-    # Is it valid to update to string? - should return WarningCollector
+    # Is it valid to update to string? - should coerce it to a 1.0, so no warning
     validity_warnings = input_obj.is_valid_update("true")
-    assert validity_warnings.has_warnings("user")
+    assert not validity_warnings.has_warnings("user")
 
-    user_warnings = validity_warnings.get_by_field("user")
-    assert any(
-        "unable to parse string as a number" in w.message.lower() for w in user_warnings
-    )
-
-    # Is it valid to update to 0.5?
+    # Is it valid to update to 0.5? Should be coerced to 1.0, so no warning
     validity_warnings = input_obj.is_valid_update(0.5)
-    assert validity_warnings.has_warnings("user")
+    assert not validity_warnings.has_warnings("user")
 
-    user_warnings = validity_warnings.get_by_field("user")
-    assert any("0.5 should be 1.0 or 0.0" in w.message for w in user_warnings)
-
-    # Try to update to 0.5 - should not change value but add warning
+    # Try to update to 0.5 - should change value to 1.0 and not add warning
     input_obj.user = 0.5
-    assert input_obj.user == 0.0  # Should not change
-    assert input_obj.warnings.has_warnings("user")  # Should have warning
+    assert input_obj.user == 1.0  # Should be coerced
+    assert not input_obj.warnings.has_warnings("user")  # Should not have warning
 
     # Reset the input
     input_obj.user = "reset"


### PR DESCRIPTION
Simplified to_dataframe for inputs and handled enums

- Moved the try/except to the inputs model level
- Simplified inputs pack and tried to minify to_dataframe as much as possible
- Handled list stringification in the pack in _to_dataframe in the end to avoid issues with update validation