### PR TITLE
Load saved scenario runner

### DIFF
--- a/examples/fetch_saved_scenario.ipynb
+++ b/examples/fetch_saved_scenario.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Saved Scenarios Demonstration\n",
+    "\n",
+    "So far:\n",
+    "1. **FetchSavedScenarioRunner** - Get details of a saved scenario"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from example_helpers import setup_notebook\n",
+    "setup_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyetm.clients.base_client import BaseClient\n",
+    "from pyetm.services.scenario_runners.fetch_saved_scenario import FetchSavedScenarioRunner\n",
+    "\n",
+    "client = BaseClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch Saved Scenario\n",
+    "\n",
+    "Retrieve detailed information about the saved scenario."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a simple object with an id attribute\n",
+    "class SavedScenarioRef:\n",
+    "    def __init__(self, saved_id):\n",
+    "        self.id = saved_id\n",
+    "saved_ref = SavedScenarioRef(5586)\n",
+    "\n",
+    "fetch_result = FetchSavedScenarioRunner.run(client, saved_ref)\n",
+    "\n",
+    "if fetch_result.success:\n",
+    "    data = fetch_result.data\n",
+    "    print(f\"Saved Scenario {data['id']}:\")\n",
+    "    print(f\"  Title: {data['title']}\")\n",
+    "    print(f\"  Description: {data.get('description')}\")\n",
+    "    print(f\"  Scenario ID: {data['scenario_id']}\")\n",
+    "    print(f\"  Private: {data['private']}\")\n",
+    "else:\n",
+    "    print(f\"Error: {fetch_result.errors}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyetm-Rh4Np-o3-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/pyetm/clients/session.py
+++ b/src/pyetm/clients/session.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import Optional, Dict
-from pydantic import BaseModel, field_validator
+from typing import Optional, Dict, Any
+from pydantic import BaseModel, field_validator, ValidationInfo
 
 import aiohttp
 from pyetm.config.settings import get_settings
@@ -45,17 +45,17 @@ class ETMResponse(BaseModel):
 
     @field_validator("status_code", mode="before")
     @classmethod
-    def raise_for_status(cls, value, info) -> None:
+    def raise_for_status(cls, value, info: ValidationInfo) -> int:
         """Raise appropriate exception for HTTP errors."""
         if value == 401:
             raise PermissionError("Invalid or missing ETM_API_TOKEN")
 
+        text = info.data.get("text", "")
+
         if 400 <= value < 500:
-            text = info.data.get("text", "")
             raise ValueError(f"HTTP {value}: {text}")
 
         if 500 <= value < 600:
-            text = info.data.get("text", "")
             raise ConnectionError(f"HTTP {value}: {text}")
 
         return value

--- a/src/pyetm/services/scenario_runners/base_runner.py
+++ b/src/pyetm/services/scenario_runners/base_runner.py
@@ -1,9 +1,16 @@
-from typing import Any, Dict, List, Optional, TypeVar, Generic
+from typing import Any, Dict, List, Optional, TypeVar, Generic, Protocol
 from abc import ABC, abstractmethod
 from ..service_result import ServiceResult
 from pyetm.clients.base_client import BaseClient, make_batch_requests
 
 T = TypeVar("T")
+
+
+class ScenarioIdentifier(Protocol):
+    """Protocol for objects with a scenario or saved_scenario ID."""
+
+    @property
+    def id(self) -> int: ...
 
 
 class BaseRunner(ABC, Generic[T]):
@@ -92,6 +99,32 @@ class BaseRunner(ABC, Generic[T]):
             formatted_requests.append(formatted)
 
         return make_batch_requests(client, formatted_requests)
+
+    @classmethod
+    def _validate_response_keys(
+        cls, data: Dict[str, Any], required_keys: List[str], fill_missing: bool = False
+    ) -> tuple[Dict[str, Any], List[str]]:
+        """
+        Validate that response contains required keys.
+
+        Args:
+            data: Response data to validate
+            required_keys: Keys that should be present
+            fill_missing: If True, add None for missing keys; if False, only warn
+
+        Returns:
+            (validated_data, warnings) tuple
+        """
+        warnings = []
+        result = data.copy() if fill_missing else data
+
+        for key in required_keys:
+            if key not in data:
+                warnings.append(f"Missing field in response: {key!r}")
+                if fill_missing:
+                    result[key] = None
+
+        return result, warnings
 
     @staticmethod
     @abstractmethod

--- a/src/pyetm/services/scenario_runners/fetch_metadata.py
+++ b/src/pyetm/services/scenario_runners/fetch_metadata.py
@@ -41,17 +41,10 @@ class FetchMetadataRunner(BaseRunner[Dict[str, Any]]):
         if not result.success:
             return result
 
-        # Custom post-processing for metadata
-        body = result.data
-        meta: Dict[str, Any] = {}
-        warnings: list[str] = []
+        validated_data, warnings = FetchMetadataRunner._validate_response_keys(
+            result.data,
+            FetchMetadataRunner.META_KEYS,
+            fill_missing=True
+        )
 
-        for key in FetchMetadataRunner.META_KEYS:
-            if key in body:
-                meta[key] = body[key]
-            else:
-                # non-breaking: warning
-                meta[key] = None
-                warnings.append(f"Missing field in response: {key!r}")
-
-        return ServiceResult.ok(data=meta, errors=warnings)
+        return ServiceResult.ok(data=validated_data, errors=warnings)

--- a/src/pyetm/services/scenario_runners/fetch_saved_scenario.py
+++ b/src/pyetm/services/scenario_runners/fetch_saved_scenario.py
@@ -1,0 +1,51 @@
+from typing import Dict, Any
+from pyetm.services.scenario_runners.base_runner import BaseRunner, ScenarioIdentifier
+from ..service_result import ServiceResult
+from pyetm.clients.base_client import BaseClient
+
+
+class FetchSavedScenarioRunner(BaseRunner[Dict[str, Any]]):
+    """
+    Runner for fetching a SavedScenario from MyETM by its ID.
+
+    GET /api/v3/saved_scenarios/{saved_scenario_id}
+    """
+
+    REQUIRED_KEYS = [
+        "id",
+        "scenario_id",
+        "title",
+        "private",
+        "created_at",
+        "updated_at",
+    ]
+
+    @staticmethod
+    def run(
+        client: BaseClient,
+        saved_scenario: ScenarioIdentifier,
+    ) -> ServiceResult[Dict[str, Any]]:
+        """
+        Fetch a single SavedScenario by ID.
+
+        Args:
+            client: HTTP client
+            saved_scenario: Object with an 'id' attribute
+
+        Returns:
+            ServiceResult with SavedScenario data
+        """
+        result = FetchSavedScenarioRunner._make_request(
+            client=client, method="get", path=f"/saved_scenarios/{saved_scenario.id}"
+        )
+
+        if not result.success:
+            return result
+
+        _, warnings = FetchSavedScenarioRunner._validate_response_keys(
+            result.data,
+            FetchSavedScenarioRunner.REQUIRED_KEYS,
+            fill_missing=False
+        )
+
+        return ServiceResult.ok(data=result.data, errors=warnings)

--- a/tests/services/scenario_runners/test_fetch_saved_scenario.py
+++ b/tests/services/scenario_runners/test_fetch_saved_scenario.py
@@ -1,0 +1,60 @@
+from pyetm.services.scenario_runners.fetch_saved_scenario import (
+    FetchSavedScenarioRunner,
+)
+
+
+def test_fetch_saved_scenario_success(dummy_client, fake_response, dummy_scenario):
+    body = {
+        "id": 1,
+        "scenario_id": 123,
+        "title": "Fetched Scenario",
+        "description": "Test description",
+        "private": False,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    }
+    response = fake_response(ok=True, status_code=200, json_data=body)
+    client = dummy_client(response, method="get")
+
+    saved_scenario = dummy_scenario(1)
+
+    result = FetchSavedScenarioRunner.run(client, saved_scenario)
+    assert result.success is True
+    assert result.data["id"] == 1
+    assert result.data["scenario_id"] == 123
+    assert result.data["title"] == "Fetched Scenario"
+    assert client.calls == [("/saved_scenarios/1", None)]
+
+
+def test_fetch_saved_scenario_missing_fields_warning(
+    dummy_client, fake_response, dummy_scenario
+):
+    # Response missing some fields
+    body = {
+        "id": 2,
+        "scenario_id": 456,
+        "title": "Incomplete",
+        # Missing: description, private, created_at, updated_at
+    }
+    response = fake_response(ok=True, status_code=200, json_data=body)
+    client = dummy_client(response, method="get")
+
+    saved_scenario = dummy_scenario(2)
+
+    result = FetchSavedScenarioRunner.run(client, saved_scenario)
+    assert result.success is True
+    assert result.data["id"] == 2
+    assert "description" not in result.data  # Missing fields not filled
+    # Should have warnings for missing fields
+    assert any("Missing field in response" in err for err in result.errors)
+
+
+def test_fetch_saved_scenario_not_found(dummy_client, fake_response, dummy_scenario):
+    response = fake_response(ok=False, status_code=404, text="Not Found")
+    client = dummy_client(response, method="get")
+
+    saved_scenario = dummy_scenario(999)
+
+    result = FetchSavedScenarioRunner.run(client, saved_scenario)
+    assert result.success is False
+    assert result.errors == ["404: Not Found"]


### PR DESCRIPTION
## Description
This PR adds a fetch saved scenario runner, along with [this minor change in myetm.](https://github.com/quintel/my-etm/pull/206)

The changes:
- `fetch_scenario_runner.py` - mimics `fetch_metadata.py` runner.
- Demonstration of the functionality in a minimal Jupyter notebook
- Refactored common parts of metadata and saved scenario fetch runners
- Minor fix for the way errors are caught in `session.py`


Closes #103 
