### PR TITLE
Extract ValidationError error message from pydantic and format it nicely

### DIFF
--- a/src/pyetm/clients/session.py
+++ b/src/pyetm/clients/session.py
@@ -43,22 +43,16 @@ class ETMResponse(BaseModel):
         """Get response content as bytes."""
         return self._content or self.text.encode("utf-8")
 
-    @field_validator("status_code", mode="before")
-    @classmethod
-    def raise_for_status(cls, value, info: ValidationInfo) -> None:
+    def raise_for_status(self) -> None:
         """Raise appropriate exception for HTTP errors."""
-        if value == 401:
+        if self.status_code == 401:
             raise PermissionError("Invalid or missing ETM_API_TOKEN")
 
-        text = info.data.get("text", "")
+        if 400 <= self.status_code < 500:
+            raise ValueError(f"{self.status_code}: {self.text}")
 
-        if 400 <= value < 500:
-            raise ValueError(f"HTTP {value}: {text}")
-
-        if 500 <= value < 600:
-            raise ConnectionError(f"HTTP {value}: {text}")
-
-        return value
+        if 500 <= self.status_code < 600:
+            raise ConnectionError(f"{self.status_code}: {self.text}")
 
 
 # TODO: Extract utils and organise private methods
@@ -155,23 +149,37 @@ class ETMSession:
         async with self._session.request(
             method, full_url, **request_kwargs
         ) as response:
-            etm_response = ETMResponse(
-                status_code=response.status,
-                headers=dict(response.headers),
-                url=str(response.url),
-            )
-
+            # Fetch response data first before creating ETMResponse
+            # so field validators have access to all data
+            status_code = response.status
+            headers = dict(response.headers)
+            url = str(response.url)
             content_type = response.headers.get("content-type", "").lower()
+
+            text = await response.text()
+            json_data = None
+            content = b""
 
             if "application/json" in content_type:
                 try:
-                    etm_response._json_data = await response.json()
-                    etm_response.text = await response.text()
+                    json_data = await response.json()
                 except Exception:
-                    etm_response.text = await response.text()
+                    pass
             else:
-                etm_response.text = await response.text()
-                etm_response._content = await response.read()
+                content = await response.read()
+
+            # Create ETMResponse and check for HTTP errors
+            etm_response = ETMResponse(
+                status_code=status_code,
+                headers=headers,
+                url=url,
+                text=text,
+            )
+            etm_response._json_data = json_data
+            etm_response._content = content
+
+            # Raise exceptions for HTTP errors
+            etm_response.raise_for_status()
 
             return etm_response
 

--- a/src/pyetm/models/saved_scenario.py
+++ b/src/pyetm/models/saved_scenario.py
@@ -67,7 +67,7 @@ class SavedScenario(Base):
 
         if not result.success:
             raise SavedScenarioError(
-                f"Could not create saved scenario: {result.errors}"
+                f"Could not create saved scenario:\n{result.error_message()}"
             )
 
         saved_scenario = cls.model_validate(result.data)
@@ -128,7 +128,7 @@ class SavedScenario(Base):
 
         if not result.success:
             raise SavedScenarioError(
-                f"Could not load saved scenario {saved_scenario_id}: {result.errors}"
+                f"Could not load saved scenario {saved_scenario_id}:\n{result.error_message()}"
             )
 
         saved_scenario = cls.model_validate(result.data)
@@ -200,7 +200,7 @@ class SavedScenario(Base):
 
         if not result.success:
             raise SavedScenarioError(
-                f"Could not update saved scenario: {result.errors}"
+                f"Could not update saved scenario:\n{result.error_message()}"
             )
 
         for warning in result.errors:

--- a/src/pyetm/models/scenario.py
+++ b/src/pyetm/models/scenario.py
@@ -83,7 +83,7 @@ class Scenario(Base):
         result = CreateScenarioRunner.run(BaseClient(), scenario_data)
 
         if not result.success:
-            raise ScenarioError(f"Could not create scenario: {result.errors}")
+            raise ScenarioError(f"Could not create scenario:\n{result.error_message()}")
 
         scenario = cls.model_validate(result.data)
         for warning in result.errors:
@@ -105,7 +105,7 @@ class Scenario(Base):
 
         if not result.success:
             raise ScenarioError(
-                f"Could not load scenario {scenario_id}: {result.errors}"
+                f"Could not load scenario {scenario_id}:\n{result.error_message()}"
             )
 
         # parse into a Scenario
@@ -127,7 +127,7 @@ class Scenario(Base):
         result = CopyScenarioRunner.run(BaseClient(), self.id, overrides=overrides)
 
         if not result.success:
-            raise ScenarioError(f"Failed to copy scenario: {result.errors}")
+            raise ScenarioError(f"Failed to copy scenario:\n{result.error_message()}")
 
         # Create and return new scenario
         scenario = Scenario.model_validate(result.data)
@@ -148,7 +148,7 @@ class Scenario(Base):
 
         if not result.success:
             raise ScenarioError(
-                f"Copied scenario but failed to break template link: {result.errors}"
+                f"Copied scenario but failed to break template link:\n{result.error_message()}"
             )
 
         if result.data and "scenario" in result.data:
@@ -219,7 +219,7 @@ class Scenario(Base):
         result = UpdateMetadataRunner.run(BaseClient(), self, kwargs)
 
         if not result.success:
-            raise ScenarioError(f"Could not update metadata: {result.errors}")
+            raise ScenarioError(f"Could not update metadata:\n{result.error_message()}")
 
         # Add any warnings from the update
         for w in result.errors:
@@ -327,7 +327,7 @@ class Scenario(Base):
         # Otherwise fetch and cache
         result = FetchInputsRunner.run(BaseClient(), self, defaults="original")
         if not result.success:
-            raise ScenarioError(f"Could not retrieve inputs: {result.errors}")
+            raise ScenarioError(f"Could not retrieve inputs:\n{result.error_message()}")
 
         coll = Inputs.from_json(result.data)
         # merge runner warnings and any item‐level warnings
@@ -364,7 +364,7 @@ class Scenario(Base):
         result = UpdateInputsRunner.run(BaseClient(), self, update_inputs)
 
         if not result.success:
-            raise ScenarioError(f"Could not update user values: {result.errors}")
+            raise ScenarioError(f"Could not update user values:\n{result.error_message()}")
 
         self.inputs.update(update_inputs)
 
@@ -379,7 +379,7 @@ class Scenario(Base):
         result = UpdateInputsRunner.run(BaseClient(), self, reset_inputs)
 
         if not result.success:
-            raise ScenarioError(f"Could not remove inputs: {result.errors}")
+            raise ScenarioError(f"Could not remove inputs:\n{result.error_message()}")
 
         # Update them in the Inputs object
         self.inputs.update(reset_inputs)
@@ -391,7 +391,7 @@ class Scenario(Base):
 
         result = FetchSortablesRunner.run(BaseClient(), self)
         if not result.success:
-            raise ScenarioError(f"Could not retrieve sortables: {result.errors}")
+            raise ScenarioError(f"Could not retrieve sortables:\n{result.error_message()}")
 
         coll = Sortables.from_json(result.data)
         for w in result.errors:
@@ -438,7 +438,7 @@ class Scenario(Base):
 
             if not result.success:
                 raise ScenarioError(
-                    f"Could not update sortable '{name}': {result.errors}"
+                    f"Could not update sortable '{name}':\n{result.error_message()}"
                 )
 
         self.sortables.update(update_sortables)
@@ -463,7 +463,7 @@ class Scenario(Base):
 
             if not result.success:
                 raise ScenarioError(
-                    f"Could not remove sortable '{name}': {result.errors}"
+                    f"Could not remove sortable '{name}':\n{result.error_message()}"
                 )
 
         reset_sortables = {name: [] for name in sortable_names}
@@ -476,7 +476,7 @@ class Scenario(Base):
 
         result = FetchAllCustomCurveDataRunner.run(BaseClient(), self)
         if not result.success:
-            raise ScenarioError(f"Could not retrieve custom_curves: {result.errors}")
+            raise ScenarioError(f"Could not retrieve custom_curves:\n{result.error_message()}")
 
         coll = CustomCurves.from_json(result.data)
         try:
@@ -513,7 +513,7 @@ class Scenario(Base):
         # Upload curves
         result = UpdateCustomCurvesRunner.run(BaseClient(), self, custom_curves)
         if not result.success:
-            raise ScenarioError(f"Could not update custom curves: {result.errors}")
+            raise ScenarioError(f"Could not update custom curves:\n{result.error_message()}")
 
         # TODO: this should be done in custom curves
         # Update the scenario's custom curves object
@@ -641,7 +641,7 @@ class Scenario(Base):
 
         result = FetchCouplingsRunner.run(BaseClient(), self)
         if not result.success:
-            raise ScenarioError(f"Could not retrieve couplings: {result.errors}")
+            raise ScenarioError(f"Could not retrieve couplings:\n{result.error_message()}")
 
         coll = Couplings.from_json(result.data)
         for w in result.errors:
@@ -660,7 +660,7 @@ class Scenario(Base):
         )
 
         if not result.success:
-            raise ScenarioError(f"Could not update couplings: {result.errors}")
+            raise ScenarioError(f"Could not update couplings:\n{result.error_message()}")
 
         # Update the cached couplings with the response data
         if self._couplings is not None:

--- a/src/pyetm/models/scenarios.py
+++ b/src/pyetm/models/scenarios.py
@@ -37,7 +37,7 @@ class Scenarios(Base):
             try:
                 scenarios.append(Scenario.load(sid))
             except ScenarioError as e:
-                print(f"Could not load scenario {sid}: {e}")
+                print(e)
         return cls(items=scenarios)
 
     @classmethod

--- a/src/pyetm/services/scenario_runners/base_runner.py
+++ b/src/pyetm/services/scenario_runners/base_runner.py
@@ -60,20 +60,71 @@ class BaseRunner(ABC, Generic[T]):
             if resp.ok:
                 # For JSON responses, parse automatically
                 try:
-                    return ServiceResult.ok(data=resp.json())
+                    data = resp.json()
+                    # Check if response contains errors even though HTTP status is OK
+                    if isinstance(data, dict) and "errors" in data:
+                        errors = data.get("errors", [])
+                        # If errors is a list of strings, use those as error messages
+                        if isinstance(errors, list) and errors:
+                            return ServiceResult.fail(errors)
+                    return ServiceResult.ok(data=data)
                 except ValueError:
                     # Not JSON, return raw response
                     return ServiceResult.ok(data=resp)
 
-            # HTTP-level failure is breaking
-            return ServiceResult.fail([f"{resp.status_code}: {resp.text}"])
+            # HTTP-level failure - parse and format error
+            error_msg = f"{resp.status_code}: {resp.text}"
+            cleaned = cls._parse_json_error(error_msg)
+            return ServiceResult.fail([cleaned])
 
         except (PermissionError, ValueError, ConnectionError) as e:
-            # These are HTTP errors from our _handle_errors method
-            return ServiceResult.fail([str(e)])
+            # HTTP errors from raise_for_status()
+            # Try to parse and clean up JSON error responses
+            error_msg = str(e)
+            cleaned = cls._parse_json_error(error_msg)
+            return ServiceResult.fail([cleaned])
         except Exception as e:
-            # Any other unexpected exception is treated as breaking
+            # Any other unexpected exception
             return ServiceResult.fail([str(e)])
+
+    @staticmethod
+    def _parse_json_error(error_msg: str) -> str:
+        """
+        Parse JSON error responses and format them nicely.
+
+        Converts "422: {\"errors\":{\"field\":[\"message\"]}}"
+        to "422: field message"
+        """
+        import json
+
+        if ": " not in error_msg:
+            return error_msg
+
+        try:
+            status_part, json_part = error_msg.split(": ", 1)
+            data = json.loads(json_part)
+
+            if isinstance(data, dict) and "errors" in data:
+                errors = data["errors"]
+                parsed = []
+
+                # Handle dict of field errors: {"field": ["msg1", "msg2"]}
+                if isinstance(errors, dict):
+                    for field, messages in errors.items():
+                        if isinstance(messages, list):
+                            parsed.extend(f"{field} {m}" for m in messages)
+                        else:
+                            parsed.append(f"{field} {messages}")
+                # Handle list of error strings: ["msg1", "msg2"]
+                elif isinstance(errors, list):
+                    parsed = errors
+
+                if parsed:
+                    return f"{status_part}: {'; '.join(parsed)}"
+        except (ValueError, json.JSONDecodeError):
+            pass
+
+        return error_msg
 
     @classmethod
     def _make_batch_requests(

--- a/src/pyetm/services/service_result.py
+++ b/src/pyetm/services/service_result.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 T = TypeVar("T")
 
+
 class ServiceResult(BaseModel, Generic[T]):
     """
     A uniform result object for all service runners.
@@ -29,6 +30,12 @@ class ServiceResult(BaseModel, Generic[T]):
         """Use when a critical error happened and you cannot proceed."""
         err_copy: list[str] = list(errors)
         return cls(success=False, data=None, errors=err_copy)
+
+    def error_message(self) -> str:
+        """
+        Return a newline-separated error message string or "Unknown error" if empty.
+        """
+        return "\n".join(self.errors) if self.errors else "Unknown error"
 
     def __repr__(self) -> str:
         # represent presence of data with an ellipsis, absence with None


### PR DESCRIPTION
## Description
As per this comment](https://github.com/quintel/pyetm/pull/107#discussion_r2623589366) I saw that the errors were not always being handled gracefully in notebooks.

These changes lead to simple error messages such as:
```
Could not load scenario 1359192:
404: No such scenario: 1359192
```

As you can see from the change in src/pyetm/models/scenarios.py, because the errors are already well formed, plural classes (e.g. Scenarios) need only surface the errors when calling underlying singular class methods (e.g. Scenario.load()). That probably requires further examination/testing to see which cases might be rending error messages twice.

- [ ] Investigate and test further 'double' error messages on 'plural' classes.

