### PR TITLE
Specify curve type for exports to only fetch that type

### DIFF
--- a/examples/advanced_features.ipynb
+++ b/examples/advanced_features.ipynb
@@ -283,7 +283,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# packer.exports().head(15) # Exports are the output curves, these take some time to generate. Uncomment to run"
+    "# Exports are the output curves, these take some time to generate.\n",
+    "# packer.exports().head(15) # Uncomment if you want all exports\n",
+    "\n",
+    "# Filter to specific curves using the curves parameter\n",
+    "packer.exports(curves=[\"merit_order\", \"electricity_price\"]).head(15)"
    ]
   },
   {

--- a/src/pyetm/models/output_curves.py
+++ b/src/pyetm/models/output_curves.py
@@ -159,9 +159,9 @@ class OutputCurves(Base):
         """Returns true if that curve is attached"""
         return any((curve_name == key for key in self.attached_keys()))
 
-    def attached_keys(self):
-        """Returns the keys of attached curves"""
-        yield from (curve.key for curve in self.curves)
+    def attached_keys(self) -> list[str]:
+        """Returns the keys of attached curves."""
+        return [curve.key for curve in self.curves]
 
     def get_contents(self, scenario, curve_name: str) -> Optional[pd.DataFrame]:
         curve = self._find(curve_name)

--- a/src/pyetm/models/packables/output_curves_pack.py
+++ b/src/pyetm/models/packables/output_curves_pack.py
@@ -23,21 +23,112 @@ class OutputCurvesPack(Packable):
     key: ClassVar[str] = "output_curves"
     sheet_name: ClassVar[str] = "OUTPUT_CURVES"
 
-    def _build_dataframe_for_scenario(self, scenario: Any, columns: str = "", **kwargs):
+    def _build_dataframe_for_scenario(
+        self,
+        scenario: Any,
+        columns: str = "",
+        curves: Optional[Sequence[str]] = None,
+        **kwargs,
+    ):
+        """
+        Build a DataFrame for one scenario with a two-level column MultiIndex:
+            (curve_type, original_column)
+        """
         try:
-            series_list = list(scenario.all_output_curves())
+            frames: list[pd.DataFrame] = []
+            keys: list[str] = []
+
+            # Determine which curves to fetch
+            if curves is not None:
+                # Only fetch specified curves
+                curves_to_fetch = [
+                    c for c in curves if scenario.output_curves.is_attached(c)
+                ]
+            else:
+                # Fetch all attached curves
+                curves_to_fetch = scenario.output_curves.attached_keys()
+
+            for curve_name in curves_to_fetch:
+                df = scenario.output_curve(curve_name)
+                if df is None or df.empty:
+                    continue
+                frames.append(df)
+                keys.append(curve_name)
+
             self.log_scenario_warnings(scenario, "_output_curves", "Output curves")
         except Exception as e:
             logger.warning(
                 "Failed extracting output curves for %s: %s", scenario.identifier(), e
             )
             return None
-        if not series_list:
-            return None
-        return pd.concat(series_list, axis=1)
 
-    def _to_dataframe(self, columns="", **kwargs) -> pd.DataFrame:
-        return self.build_pack_dataframe(columns=columns, **kwargs)
+        if not frames:
+            return None
+
+        return pd.concat(frames, axis=1, keys=keys, names=["curve_type"])
+
+    def to_dataframe(
+        self, columns="", curves: Optional[Sequence[str]] = None, **kwargs
+    ) -> pd.DataFrame:
+        """
+        Build a DataFrame with optional curve filtering.
+        """
+        if len(self.scenarios) == 0:
+            return pd.DataFrame()
+
+        df = self._to_dataframe(columns=columns, curves=curves, **kwargs)
+
+        if df.empty:
+            return df
+
+        # Filter curves if specified
+        if curves is not None and df.columns.nlevels >= 2:
+            # Get available curve types from the MultiIndex
+            available_curves = df.columns.get_level_values(1).unique()
+            # Filter to only requested curves that exist
+            valid_curves = [c for c in curves if c in available_curves]
+            if valid_curves:
+                # Select columns where level 1 matches
+                mask = df.columns.get_level_values(1).isin(valid_curves)
+                df = df.loc[:, mask]
+            else:
+                # No valid curves found, return empty
+                return pd.DataFrame()
+
+        return df
+
+    def _to_dataframe(
+        self, columns="", curves: Optional[Sequence[str]] = None, **kwargs
+    ) -> pd.DataFrame:
+        return self.build_pack_dataframe(columns=columns, curves=curves, **kwargs)
+
+    def build_pack_dataframe(
+        self, columns: str = "", curves: Optional[Sequence[str]] = None, **kwargs
+    ) -> pd.DataFrame:
+        """
+        Override base build_pack_dataframe to pass curves filter to _build_dataframe_for_scenario.
+        """
+        frames: list[pd.DataFrame] = []
+        keys: list[Any] = []
+        for scenario in self.scenarios:
+            try:
+                df = self._build_dataframe_for_scenario(
+                    scenario, columns=columns, curves=curves, **kwargs
+                )
+                self.log_scenario_warnings(scenario, self.key, self.sheet_name)
+            except Exception as e:
+                logger.warning(
+                    "Failed building frame for scenario %s in %s: %s",
+                    scenario.identifier(),
+                    self.__class__.__name__,
+                    e,
+                )
+                continue
+            if df is None or df.empty:
+                continue
+            frames.append(df)
+            keys.append(self._key_for(scenario))
+        return self._concat_frames(frames, keys)
 
     def to_excel_per_carrier(
         self, path: str, carriers: Optional[Sequence[str]] = None

--- a/src/pyetm/models/scenario_packer.py
+++ b/src/pyetm/models/scenario_packer.py
@@ -82,8 +82,8 @@ class ScenarioPacker(BaseModel):
     def custom_curves(self) -> pd.DataFrame:
         return self._custom_curves.to_dataframe()
 
-    def exports(self) -> pd.DataFrame:
-        return self._exports.to_dataframe()
+    def exports(self, curves: Optional[Sequence[str]] = None) -> pd.DataFrame:
+        return self._exports.to_dataframe(curves=curves)
 
     def couplings(self) -> pd.DataFrame:
         if len(self._scenarios()) == 0:

--- a/tests/models/packables/test_output_curves_pack.py
+++ b/tests/models/packables/test_output_curves_pack.py
@@ -13,24 +13,38 @@ def make_scenario(id_val="S"):
     return s
 
 
+def _attach_output_curves(scenario, curve_dict: dict):
+    """
+    Wire up scenario.output_curves.attached_keys() and scenario.output_curve()
+    to return data from curve_dict, keyed by curve name.
+    """
+    scenario.output_curves = Mock()
+    scenario.output_curves.attached_keys = Mock(return_value=list(curve_dict.keys()))
+    scenario.output_curve = Mock(side_effect=lambda name: curve_dict.get(name))
+
+
 def test_to_dataframe_collects_series():
     s = make_scenario()
-    s.all_output_curves.return_value = [
-        pd.Series([1, 2], name="c1"),
-        pd.Series([3, 4], name="c2"),
-    ]
+    _attach_output_curves(s, {
+        "merit_order": pd.DataFrame({"wind": [1, 2], "solar": [3, 4]}),
+        "electricity_price": pd.DataFrame({"value": [10, 20]}),
+    })
 
     pack = OutputCurvesPack()
     pack.add(s)
 
     df = pack.to_dataframe()
     assert not df.empty
-    assert "c1" in df.columns.get_level_values(1) or "c1" in df.columns
+    # Level 0 is the scenario identifier; level 1 is curve_type
+    assert "merit_order" in df.columns.get_level_values(1)
+    assert "electricity_price" in df.columns.get_level_values(1)
 
 
 def test_to_dataframe_handles_exception_and_empty(caplog):
     s = make_scenario()
-    s.all_output_curves.side_effect = RuntimeError("fail")
+    # Force the output_curves accessor to raise
+    s.output_curves = Mock()
+    s.output_curves.attached_keys = Mock(side_effect=RuntimeError("fail"))
 
     pack = OutputCurvesPack()
     pack.add(s)
@@ -40,8 +54,8 @@ def test_to_dataframe_handles_exception_and_empty(caplog):
         assert df.empty
         assert "Failed extracting output curves" in caplog.text
 
-    s.all_output_curves.side_effect = None
-    s.all_output_curves.return_value = []
+    # Now wire up an empty set of curves
+    _attach_output_curves(s, {})
     df2 = pack.to_dataframe()
     assert df2.empty
 
@@ -49,7 +63,7 @@ def test_to_dataframe_handles_exception_and_empty(caplog):
 def test_build_dataframe_with_warnings(caplog):
     """Test the warning logging branch when scenario has _output_curves."""
     s = make_scenario()
-    s.all_output_curves.return_value = [pd.Series([1, 2], name="test")]
+    _attach_output_curves(s, {"merit_order": pd.DataFrame({"wind": [1, 2]})})
 
     # Mock _output_curves with log_warnings method
     mock_output_curves = Mock()
@@ -69,7 +83,7 @@ def test_build_dataframe_with_warnings(caplog):
 def test_build_dataframe_warning_logging_exception():
     """Test exception handling in warning logging branch."""
     s = make_scenario()
-    s.all_output_curves.return_value = [pd.Series([1, 2], name="test")]
+    _attach_output_curves(s, {"merit_order": pd.DataFrame({"wind": [1, 2]})})
 
     # Mock _output_curves that raises exception during log_warnings
     mock_output_curves = Mock()
@@ -86,7 +100,7 @@ def test_build_dataframe_warning_logging_exception():
 def test_build_dataframe_no_output_curves_attr():
     """Test scenario without _output_curves attribute."""
     s = make_scenario()
-    s.all_output_curves.return_value = [pd.Series([1, 2], name="test")]
+    _attach_output_curves(s, {"merit_order": pd.DataFrame({"wind": [1, 2]})})
     # Don't set _output_curves attribute
 
     pack = OutputCurvesPack()
@@ -98,13 +112,53 @@ def test_build_dataframe_no_output_curves_attr():
 def test_build_dataframe_output_curves_none():
     """Test scenario with _output_curves = None."""
     s = make_scenario()
-    s.all_output_curves.return_value = [pd.Series([1, 2], name="test")]
+    _attach_output_curves(s, {"merit_order": pd.DataFrame({"wind": [1, 2]})})
     s._output_curves = None
 
     pack = OutputCurvesPack()
     df = pack._build_dataframe_for_scenario(s)
 
     assert not df.empty
+
+
+def test_build_dataframe_curve_type_multiindex():
+    """Verify the (curve_type, column) MultiIndex structure on the result."""
+    s = make_scenario()
+    _attach_output_curves(s, {
+        "merit_order": pd.DataFrame({"wind": [10, 20], "solar": [5, 15]}),
+        "electricity_price": pd.DataFrame({"value": [100, 200]}),
+    })
+
+    pack = OutputCurvesPack()
+    df = pack._build_dataframe_for_scenario(s)
+
+    # Two-level column MultiIndex: (curve_type, original_column)
+    assert df.columns.nlevels == 2
+    assert df.columns.names[0] == "curve_type"
+
+    # Can slice by curve_type
+    merit = df["merit_order"]
+    assert list(merit.columns) == ["wind", "solar"]
+    assert list(merit["wind"]) == [10, 20]
+
+    price = df["electricity_price"]
+    assert list(price.columns) == ["value"]
+    assert list(price["value"]) == [100, 200]
+
+
+def test_build_dataframe_skips_none_and_empty_curves():
+    """Curves that return None or empty DataFrames are excluded."""
+    s = make_scenario()
+    _attach_output_curves(s, {
+        "merit_order": pd.DataFrame({"wind": [1]}),
+        "empty_curve": pd.DataFrame(),           # empty
+        "none_curve": None,                      # None
+    })
+
+    pack = OutputCurvesPack()
+    df = pack._build_dataframe_for_scenario(s)
+
+    assert df.columns.get_level_values(0).tolist() == ["merit_order"]
 
 
 def test_to_excel_per_carrier_no_scenarios(carrier_mappings):
@@ -365,9 +419,48 @@ def test_to_dataframe_with_kwargs():
 def test_build_dataframe_with_columns_kwargs():
     """Test _build_dataframe_for_scenario with columns parameter."""
     s = make_scenario()
-    s.all_output_curves.return_value = [pd.Series([1, 2], name="test")]
+    _attach_output_curves(s, {"merit_order": pd.DataFrame({"wind": [1, 2]})})
 
     pack = OutputCurvesPack()
     df = pack._build_dataframe_for_scenario(s, columns="test_columns", extra="param")
 
     assert not df.empty
+
+
+def test_to_dataframe_with_curves_filter():
+    """Test filtering to specific curves using curves parameter."""
+    s = make_scenario()
+    _attach_output_curves(s, {
+        "merit_order": pd.DataFrame({"wind": [1, 2], "solar": [3, 4]}),
+        "electricity_price": pd.DataFrame({"value": [10, 20]}),
+        "heat_network": pd.DataFrame({"demand": [100, 200]}),
+    })
+
+    pack = OutputCurvesPack()
+    pack.add(s)
+
+    # Filter to only merit_order and electricity_price
+    df = pack.to_dataframe(curves=["merit_order", "electricity_price"])
+
+    assert not df.empty
+    # Should have 2 curve types
+    curve_types = df.columns.get_level_values(1).unique().tolist()
+    assert "merit_order" in curve_types
+    assert "electricity_price" in curve_types
+    assert "heat_network" not in curve_types
+
+
+def test_to_dataframe_with_invalid_curves_filter():
+    """Test filtering with curve names that don't exist."""
+    s = make_scenario()
+    _attach_output_curves(s, {
+        "merit_order": pd.DataFrame({"wind": [1, 2]}),
+    })
+
+    pack = OutputCurvesPack()
+    pack.add(s)
+
+    # Request curves that don't exist
+    df = pack.to_dataframe(curves=["nonexistent1", "nonexistent2"])
+
+    assert df.empty


### PR DESCRIPTION
## Description
These changes allow you to specify a curve type and filter by that type to get a subset of the multi-index. I have not processed returning a dict of dataframes.

This should reduce overall API calls and simplify the output of the exports for users.

Closes #129 
