### PR TITLE
Recieve only fields specified when indexing inputs dataframe

### DIFF
--- a/examples/advanced_features.ipynb
+++ b/examples/advanced_features.ipynb
@@ -228,9 +228,7 @@
    "id": "40ecc2e3",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "packer.inputs(columns=[\"user\", \"default\", \"min\", \"max\", \"permitted_values\"]).head(15)"
-   ]
+   "source": "packer.inputs(fields=[\"user\", \"default\", \"min\", \"max\", \"permitted_values\"]).head(15)"
   },
   {
    "cell_type": "markdown",

--- a/examples/basic_features.ipynb
+++ b/examples/basic_features.ipynb
@@ -177,13 +177,7 @@
    "id": "1f9a4600",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Inputs are displayed using combine to show them in one multi-index dataframe.\n",
-    "# You may specify the columns you like to see.\n",
-    "# With head(15) we show only the first 15 inputs, but you may use any\n",
-    "# other pandas dataframe methods you prefer.\n",
-    "scenarios.combine.inputs(columns=[\"user\", \"default\", \"min\", \"max\"]).head(15)"
-   ]
+   "source": "# Inputs are displayed using combine to show them in one multi-index dataframe.\n# You may specify the fields you like to see.\n# With head(15) we show only the first 15 inputs, but you may use any\n# other pandas dataframe methods you prefer.\nscenarios.combine.inputs(fields=[\"user\", \"default\", \"min\", \"max\"]).head(15)"
   },
   {
    "cell_type": "markdown",

--- a/src/pyetm/models/inputs.py
+++ b/src/pyetm/models/inputs.py
@@ -257,13 +257,13 @@ class Inputs(Base):
             if input_obj.key in key_vals:
                 input_obj.user = key_vals[input_obj.key]
 
-    def _to_dataframe(self, columns="user", **kwargs) -> pd.DataFrame:
+    def _to_dataframe(self, fields="user", **kwargs) -> pd.DataFrame:
         """
         Serialize the Inputs collection to DataFrame.
         """
-        if not isinstance(columns, list):
-            columns = [columns]
-        columns = ["unit"] + columns
+        if not isinstance(fields, list):
+            fields = [fields]
+        columns = ["unit"] + fields
         try:
             df = pd.DataFrame.from_dict(
                 {

--- a/src/pyetm/models/packables/inputs_pack.py
+++ b/src/pyetm/models/packables/inputs_pack.py
@@ -27,7 +27,7 @@ class InputsPack(Packable):
 
     def to_dataframe(
         self,
-        columns: str | List[str] = "user",
+        fields: str | List[str] = "user",
         *,
         include_defaults: bool = False,
         include_min_max: bool = False,
@@ -35,13 +35,10 @@ class InputsPack(Packable):
         if not self.scenarios:
             return pd.DataFrame()
 
-        if isinstance(columns, str):
-            cols = [columns] if columns else []
+        if isinstance(fields, str):
+            cols = [fields] if fields else []
         else:
-            cols = [c for c in columns if c]
-        if "user" in cols:
-            cols.remove("user")
-        cols.insert(0, "user")
+            cols = [c for c in fields if c]
 
         if include_defaults:
             for col in ("default", "permitted_values"):
@@ -54,7 +51,7 @@ class InputsPack(Packable):
 
         frames, labels = [], []
         for scenario in self.scenarios:
-            df = scenario.inputs.to_dataframe(columns=cols)
+            df = scenario.inputs.to_dataframe(fields=cols)
             if df is not None and not df.empty:
                 frames.append(df)
                 labels.append(self._get_scenario_display_key(scenario))
@@ -65,8 +62,8 @@ class InputsPack(Packable):
             else pd.DataFrame()
         )
 
-    def _to_dataframe(self, columns="user", **kwargs):
-        return self.to_dataframe(columns=columns)
+    def _to_dataframe(self, fields="user", **kwargs):
+        return self.to_dataframe(fields=fields)
 
     def add_to_workbook(
         self,

--- a/src/pyetm/models/packables/inputs_pack.py
+++ b/src/pyetm/models/packables/inputs_pack.py
@@ -36,22 +36,22 @@ class InputsPack(Packable):
             return pd.DataFrame()
 
         if isinstance(fields, str):
-            cols = [fields] if fields else []
+            fields = [fields] if fields else []
         else:
-            cols = [c for c in fields if c]
+            fields = [c for c in fields if c]
 
         if include_defaults:
             for col in ("default", "permitted_values"):
-                if col not in cols:
-                    cols.append(col)
+                if col not in fields:
+                    fields.append(col)
         if include_min_max:
             for col in ("min", "max"):
-                if col not in cols:
-                    cols.append(col)
+                if col not in fields:
+                    fields.append(col)
 
         frames, labels = [], []
         for scenario in self.scenarios:
-            df = scenario.inputs.to_dataframe(fields=cols)
+            df = scenario.inputs.to_dataframe(fields=fields)
             if df is not None and not df.empty:
                 frames.append(df)
                 labels.append(self._get_scenario_display_key(scenario))

--- a/src/pyetm/models/scenario_packer.py
+++ b/src/pyetm/models/scenario_packer.py
@@ -70,8 +70,8 @@ class ScenarioPacker(BaseModel):
             return pd.DataFrame()
         return pd.concat([scenario._to_dataframe() for scenario in scenarios], axis=1)
 
-    def inputs(self, columns="user") -> pd.DataFrame:
-        return self._inputs.to_dataframe(columns=columns)
+    def inputs(self, fields="user") -> pd.DataFrame:
+        return self._inputs.to_dataframe(fields=fields)
 
     def gquery_results(self, columns="future") -> pd.DataFrame:
         return self._query_pack.to_dataframe(columns=columns)

--- a/src/pyetm/models/session.py
+++ b/src/pyetm/models/session.py
@@ -313,7 +313,7 @@ class Session(Base):
         The scenario_id field also contains the ETEngine session ID (for consistency with Scenario exports).
         """
         info: Dict[str, Any] = {
-            "title": self.title,
+            "title": self.identifier(),
             "id": self.id,
             "scenario_id": self.id,  # Same as id, shows it's a session in mixed cases
             "template": self.template,

--- a/tests/models/packables/test_inputs_pack.py
+++ b/tests/models/packables/test_inputs_pack.py
@@ -44,13 +44,15 @@ def make_scenario(id_val=1, identifier="S1", inputs_data=None):
         # Set up to_dataframe method
         def mock_to_dataframe(fields=None):
             if isinstance(fields, list):
-                cols = fields
+                fields = fields
             else:
-                cols = [fields] if fields else ["user"]
+                fields = [fields] if fields else ["user"]
 
             data = {}
-            for col in cols:
-                data[col] = [inputs_data[key].get(col) for key in inputs_data.keys()]
+            for field in fields:
+                data[field] = [
+                    inputs_data[key].get(field) for key in inputs_data.keys()
+                ]
 
             df = pd.DataFrame(data, index=list(inputs_data.keys()))
             return df

--- a/tests/models/packables/test_inputs_pack.py
+++ b/tests/models/packables/test_inputs_pack.py
@@ -42,11 +42,11 @@ def make_scenario(id_val=1, identifier="S1", inputs_data=None):
         s.inputs.__iter__ = Mock(return_value=iter(input_objects))
 
         # Set up to_dataframe method
-        def mock_to_dataframe(columns=None):
-            if isinstance(columns, list):
-                cols = columns
+        def mock_to_dataframe(fields=None):
+            if isinstance(fields, list):
+                cols = fields
             else:
-                cols = [columns] if columns else ["user"]
+                cols = [fields] if fields else ["user"]
 
             data = {}
             for col in cols:

--- a/tests/models/test_inputs.py
+++ b/tests/models/test_inputs.py
@@ -18,14 +18,14 @@ def test_to_dataframe(inputs_json):
     input_collection = Inputs.from_json(inputs_json)
 
     df_standard = input_collection.to_dataframe()
-    df_with_defaults = input_collection.to_dataframe(columns=["user", "default"])
+    df_with_defaults = input_collection.to_dataframe(fields=["user", "default"])
 
     assert "user" in df_standard.columns
     assert "user" in df_with_defaults.columns
     assert "default" not in df_standard.columns
     assert "default" in df_with_defaults.columns
 
-    df_with_non_existing = input_collection.to_dataframe(columns="foo")
+    df_with_non_existing = input_collection.to_dataframe(fields="foo")
 
     assert df_with_non_existing["foo"].isnull().all()
 


### PR DESCRIPTION
#### Changes
- Refactored 'columns' to 'fields' in the inputs dataframe flow
- Removed the default user column from inputs dataframe when fields are explicitly specified

@robcalon tagging you again, no need to review the actual code (unless you want to!). The main idea is to functionally review the changes to make sure they meet your requirements.

Closes #131 
