### PR TITLE
Include weather curves in custom curves fetch so users can set them

### DIFF
--- a/src/pyetm/services/scenario_runners/fetch_custom_curves.py
+++ b/src/pyetm/services/scenario_runners/fetch_custom_curves.py
@@ -45,5 +45,8 @@ class FetchAllCustomCurveDataRunner(BaseRunner[Dict[str, Any]]):
         scenario: Any,
     ) -> ServiceResult[Dict[str, Any]]:
         return FetchAllCustomCurveDataRunner._make_request(
-            client=client, method="get", path=f"/scenarios/{scenario.id}/custom_curves"
+            client=client,
+            method="get",
+            path=f"/scenarios/{scenario.id}/custom_curves",
+            payload={"include_internal": True},
         )

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -94,7 +94,7 @@ def dummy_scenario():
 
 @pytest.fixture
 def custom_curves_json():
-    """JSON data for custom curves"""
+    """JSON data for custom curves (includes internal curves)"""
     return [
         {
             "attached": True,
@@ -103,4 +103,14 @@ def custom_curves_json():
         },
         {"attached": True, "key": "solar_pv_profile_1", "type": "profile"},
         {"attached": False, "key": "wind_profile_1", "type": "profile"},
+        {
+            "attached": False,
+            "key": "weather-insulation_terraced_houses_low",
+            "type": "weather_curve",
+        },
+        {
+            "attached": False,
+            "key": "weather-insulation_apartments_medium",
+            "type": "weather_curve",
+        },
     ]

--- a/tests/services/scenario_runners/test_fetch_custom_curves.py
+++ b/tests/services/scenario_runners/test_fetch_custom_curves.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from pyetm.services.scenario_runners.fetch_custom_curves import (
     DownloadCustomCurveRunner,
+    FetchAllCustomCurveDataRunner,
 )
 from pyetm.services.service_result import ServiceResult
 from pyetm.clients.session import ETMResponse
@@ -71,3 +72,49 @@ def test_multiple_curves(requests_mock, api_url, scenario, custom_curves_json):
 
     requests_mock.get(curve_url_1, status_code=200, text=csv_content)
     requests_mock.get(curve_url_2, status_code=200, text=csv_content)
+
+
+def test_fetch_all_curves_includes_internal_parameter(
+    dummy_client, fake_response, dummy_scenario
+):
+    """
+    Test that FetchAllCustomCurveDataRunner includes include_internal=true parameter.
+    This ensures internal curves (like weather-insulation curves) are accessible.
+    """
+    # Create a mock response with internal curves
+    mock_response_data = [
+        {"attached": False, "key": "solar_pv_profile_1", "type": "profile"},
+        {
+            "attached": False,
+            "key": "weather-insulation_terraced_houses_low",
+            "type": "weather_curve",
+        },
+        {
+            "attached": False,
+            "key": "weather-insulation_apartments_medium",
+            "type": "weather_curve",
+        },
+    ]
+
+    response = fake_response(ok=True, status_code=200, json_data=mock_response_data)
+    client = dummy_client(response)
+    scenario = dummy_scenario(scenario_id=12345)
+
+    result = FetchAllCustomCurveDataRunner.run(client, scenario)
+
+    # Verify the request was successful
+    assert result.success
+    assert len(result.data) == 3
+
+    # Verify that include_internal parameter was passed
+    assert len(client.calls) == 1
+    url, params = client.calls[0]
+    assert url == "/scenarios/12345/custom_curves"
+    assert params is not None
+    assert "params" in params
+    assert params["params"]["include_internal"] is True
+
+    # Verify internal curves are in the response
+    curve_keys = [curve["key"] for curve in result.data]
+    assert "weather-insulation_terraced_houses_low" in curve_keys
+    assert "weather-insulation_apartments_medium" in curve_keys


### PR DESCRIPTION
#### Context
Some weather curves are more 'advanced' functionally than the other custom curves. These curves are marked as "internal", even though they are settable via the API.

#### Implemented changes
Enabled all custom curves to be fetched and set via pyetm, including the 'internal' curves.

#### Related
Closes #144 

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
