### PR TITLE
Fix include_internal parameter for custom curves

### DIFF
--- a/src/pyetm/services/scenario_runners/fetch_custom_curves.py
+++ b/src/pyetm/services/scenario_runners/fetch_custom_curves.py
@@ -48,5 +48,5 @@ class FetchAllCustomCurveDataRunner(BaseRunner[Dict[str, Any]]):
             client=client,
             method="get",
             path=f"/scenarios/{scenario.id}/custom_curves",
-            payload={"include_internal": True},
+            payload={"include_internal": "true"},
         )

--- a/tests/services/scenario_runners/test_fetch_custom_curves.py
+++ b/tests/services/scenario_runners/test_fetch_custom_curves.py
@@ -112,7 +112,7 @@ def test_fetch_all_curves_includes_internal_parameter(
     assert url == "/scenarios/12345/custom_curves"
     assert params is not None
     assert "params" in params
-    assert params["params"]["include_internal"] is True
+    assert params["params"]["include_internal"] == "true"
 
     # Verify internal curves are in the response
     curve_keys = [curve["key"] for curve in result.data]


### PR DESCRIPTION
#### Context
pyetm was passing Python True to aiohttp, which only accepts str, int, or float in query parameters

#### Implemented changes
- Passed true as a string

#### Related
Closes #151 
Closes #150 

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
