### PR TITLE
Fix template inheritance and standardize template_id

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -111,6 +111,7 @@ Basic usage to create + run a scenario and fetch results:
 from pyetm import Scenario
 
 # Create a scenario from a template / region code (example numbers are illustrative)
+# Note: template_id expects Session ID (ETEngine), not SavedScenario ID (MyETM)
 scen = Scenario.create(region=205, end_year=2050, template_id=12345)
 
 # Update some inputs

--- a/Contributing.md
+++ b/Contributing.md
@@ -111,7 +111,7 @@ Basic usage to create + run a scenario and fetch results:
 from pyetm import Scenario
 
 # Create a scenario from a template / region code (example numbers are illustrative)
-scen = Scenario.create(region=205, end_year=2050, template=12345)
+scen = Scenario.create(region=205, end_year=2050, template_id=12345)
 
 # Update some inputs
 scen.update_inputs({

--- a/src/pyetm/models/scenario.py
+++ b/src/pyetm/models/scenario.py
@@ -358,9 +358,9 @@ class Scenario(Base):
         return self.session.start_year
 
     @property
-    def template(self) -> Optional[int]:
+    def template_id(self) -> Optional[int]:
         """Get template ID from the underlying session."""
-        return self.session.template
+        return self.session.template_id
 
     @property
     def keep_compatible(self) -> Optional[bool]:
@@ -618,7 +618,7 @@ class Scenario(Base):
         info.update(
             {
                 "session_id": self.scenario_id,
-                "preset": session.template,
+                "preset": session.template_id,
                 "area_code": session.area_code,
                 "start_year": session.start_year,
                 "end_year": session.end_year,

--- a/src/pyetm/models/scenarios.py
+++ b/src/pyetm/models/scenarios.py
@@ -233,7 +233,10 @@ class Scenarios(Base):
                     area = params.get("area_code") or area_code
                     year = params.get("end_year") or end_year
 
-                    if area is None or year is None:
+                    # Check if template_id is provided (allows inheriting area_code/end_year)
+                    has_template = "template_id" in params
+
+                    if not has_template and (area is None or year is None):
                         print(
                             f"Could not create saved scenario with {params}: "
                             "Missing area_code or end_year. Provide them in each dict or as defaults."

--- a/src/pyetm/models/scenarios.py
+++ b/src/pyetm/models/scenarios.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 class ScenarioCreationParams(TypedDict, total=False):
     """
     Type definition for create_many parameter dicts.
+
+    Note: template_id must be a Session ID (ETEngine), not a SavedScenario ID (MyETM).
     """
 
     title: Optional[str]
@@ -180,8 +182,10 @@ class Scenarios(Base):
                 - title: Title for the saved scenario (required)
                 - scenario_id: (Optional) ETEngine scenario ID to save. If not provided,
                   a new Session will be created using area_code and end_year
-                - area_code: (Optional if using defaults) Area code for new session
-                - end_year: (Optional if using defaults) End year for new session
+                - template_id: (Optional) Session ID to use as template. Inherits area_code
+                  and end_year from the template.
+                - area_code: (Optional if using defaults or template_id) Area code for new session
+                - end_year: (Optional if using defaults or template_id) End year for new session
                 - user_values: (Optional) Dict of user input values to apply after creation
                 - custom_curves: (Optional) Dict of custom curves to upload after creation
                 - sortables: (Optional) Dict of sortables to apply after creation
@@ -406,9 +410,13 @@ class Scenarios(Base):
             # Use UpdateInputsRunner to build user_values requests
             if data.get("user_values"):
                 try:
-                    request = UpdateInputsRunner.build_request(session, data["user_values"])
+                    request = UpdateInputsRunner.build_request(
+                        session, data["user_values"]
+                    )
                     requests.append(request)
-                    request_metadata.append(("user_values", scenario_idx, scenario.title))
+                    request_metadata.append(
+                        ("user_values", scenario_idx, scenario.title)
+                    )
                 except Exception as e:
                     warnings.append(
                         f"Failed to build user_values request for scenario '{scenario.title}': {e}"

--- a/src/pyetm/models/session.py
+++ b/src/pyetm/models/session.py
@@ -102,6 +102,13 @@ class Session(Base):
         """
         Create a new scenario with the specified parameters.
 
+        Args:
+            area_code: Area code for the scenario (optional if template_id is provided)
+            end_year: End year for the scenario (optional if template_id is provided)
+            **kwargs: Additional parameters including:
+                - template_id: Session ID to use as template
+                - private, keep_compatible, source, title, metadata, start_year, scaling, url
+
         Returns:
             A new Scenario instance
         """

--- a/src/pyetm/models/session.py
+++ b/src/pyetm/models/session.py
@@ -3,7 +3,7 @@ import pandas as pd
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, ConfigDict
 from os import PathLike
 from pyetm.models.couplings import Couplings
 from pyetm.models.inputs import Inputs
@@ -62,6 +62,8 @@ class Session(Base):
     but with only `id` required so it can be used for API runners.
     """
 
+    model_config = ConfigDict(validate_assignment=True, populate_by_name=True)
+
     id: int = Field(..., description="Unique scenario identifier")
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -75,8 +77,10 @@ class Session(Base):
     short_name: Optional[str] = None
     start_year: Optional[int] = None
     scaling: Optional[Any] = None
-    template: Optional[int] = Field(
-        None, description="ID of the preset scenario this was copied from"
+    template_id: Optional[int] = Field(
+        None,
+        alias="preset_scenario_id",
+        description="ID of the preset scenario this was copied from",
     )
     url: Optional[str] = None
 
@@ -92,14 +96,21 @@ class Session(Base):
     _pending_users: Dict[str, str] = PrivateAttr(default_factory=dict)
 
     @classmethod
-    def new(cls, area_code: str, end_year: int, **kwargs) -> "Session":
+    def new(
+        cls, area_code: str | None = None, end_year: int | None = None, **kwargs
+    ) -> "Session":
         """
         Create a new scenario with the specified parameters.
 
         Returns:
             A new Scenario instance
         """
-        scenario_data = {"area_code": area_code, "end_year": end_year, **kwargs}
+        scenario_data = {**kwargs}
+        if area_code is not None:
+            scenario_data["area_code"] = area_code
+        if end_year is not None:
+            scenario_data["end_year"] = end_year
+
         result = CreateScenarioRunner.run(BaseClient(), scenario_data)
 
         if not result.success:
@@ -166,8 +177,10 @@ class Session(Base):
         if result.data and "scenario" in result.data:
             scenario_data = result.data["scenario"]
             for field, value in scenario_data.items():
-                if hasattr(new_scenario, field):
-                    setattr(new_scenario, field, value)
+                # Handle alias: preset_scenario_id → template_id
+                attr_name = "template_id" if field == "preset_scenario_id" else field
+                if hasattr(new_scenario, attr_name):
+                    setattr(new_scenario, attr_name, value)
 
         return new_scenario
 
@@ -320,7 +333,7 @@ class Session(Base):
             "title": self.identifier(),
             "id": self.id,
             "scenario_id": self.id,  # Same as id, shows it's a session in mixed cases
-            "template": self.template,
+            "template_id": self.template_id,
             "area_code": self.area_code,
             "start_year": self.start_year,
             "end_year": self.end_year,
@@ -868,3 +881,8 @@ class Session(Base):
         )
         if not result.success:
             raise ScenarioError(f"Could not add user: {result.errors}")
+
+    @property
+    def preset_scenario_id(self) -> Optional[int]:
+        """Backward-compatible property for template_id (API field name)."""
+        return self.template_id

--- a/src/pyetm/services/scenario_runners/copy_scenario.py
+++ b/src/pyetm/services/scenario_runners/copy_scenario.py
@@ -23,7 +23,7 @@ class CopyScenarioRunner(BaseRunner[Dict[str, Any]]):
         "source",
         "private",
         "keep_compatible",
-        "template",
+        "template_id",
     ]
 
     @staticmethod
@@ -66,9 +66,9 @@ class CopyScenarioRunner(BaseRunner[Dict[str, Any]]):
 
             scenario_data.update(filtered_overrides)
 
-        # Transform template → preset_scenario_id for ETEngine API
-        if "template" in scenario_data:
-            scenario_data["preset_scenario_id"] = scenario_data.pop("template")
+        # Transform template_id → preset_scenario_id for ETEngine API
+        if "template_id" in scenario_data:
+            scenario_data["preset_scenario_id"] = scenario_data.pop("template_id")
 
         payload = {"scenario": scenario_data}
 

--- a/src/pyetm/services/scenario_runners/create_scenario.py
+++ b/src/pyetm/services/scenario_runners/create_scenario.py
@@ -31,7 +31,7 @@ class CreateScenarioRunner(BaseRunner[Dict[str, Any]]):
         "metadata",
         "start_year",
         "scaling",
-        "template",
+        "template_id",
         "url",
     ]
 
@@ -53,9 +53,11 @@ class CreateScenarioRunner(BaseRunner[Dict[str, Any]]):
             )
         """
         # Validate required fields
+        has_template = "template_id" in scenario_data
+
         missing_required = []
         for key in CreateScenarioRunner.REQUIRED_KEYS:
-            if key not in scenario_data:
+            if key not in scenario_data and not has_template:
                 missing_required.append(key)
 
         if missing_required:
@@ -76,8 +78,8 @@ class CreateScenarioRunner(BaseRunner[Dict[str, Any]]):
         for key in filtered_keys:
             warnings.append(f"Ignoring invalid field for scenario creation: {key!r}")
 
-        if "template" in filtered_data:
-            filtered_data["preset_scenario_id"] = filtered_data.pop("template")
+        if "template_id" in filtered_data:
+            filtered_data["preset_scenario_id"] = filtered_data.pop("template_id")
 
         payload = {"scenario": filtered_data}
 

--- a/src/pyetm/services/scenario_runners/fetch_metadata.py
+++ b/src/pyetm/services/scenario_runners/fetch_metadata.py
@@ -25,7 +25,7 @@ class FetchMetadataRunner(BaseRunner[Dict[str, Any]]):
         "title",
         "start_year",
         "scaling",
-        "template",
+        "preset_scenario_id",  # aliased to template_id in Session
         "url",
     ]
 
@@ -42,9 +42,7 @@ class FetchMetadataRunner(BaseRunner[Dict[str, Any]]):
             return result
 
         validated_data, warnings = FetchMetadataRunner._validate_response_keys(
-            result.data,
-            FetchMetadataRunner.META_KEYS,
-            fill_missing=True
+            result.data, FetchMetadataRunner.META_KEYS, fill_missing=True
         )
 
         return ServiceResult.ok(data=validated_data, errors=warnings)

--- a/src/pyetm/services/scenario_runners/update_metadata.py
+++ b/src/pyetm/services/scenario_runners/update_metadata.py
@@ -24,7 +24,7 @@ class UpdateMetadataRunner(BaseRunner[Dict[str, Any]]):
         "metadata",
         "end_year",
         "title",
-        "template",
+        "template_id",
     ]
     UNSETTABLE_META_KEYS = [
         "id",
@@ -98,8 +98,8 @@ class UpdateMetadataRunner(BaseRunner[Dict[str, Any]]):
         if final_metadata or nested_metadata or "metadata" in direct_fields:
             direct_fields["metadata"] = final_metadata
 
-        if "template" in direct_fields:
-            direct_fields["preset_scenario_id"] = direct_fields.pop("template")
+        if "template_id" in direct_fields:
+            direct_fields["preset_scenario_id"] = direct_fields.pop("template_id")
 
         # Transform metadata to the API format
         payload = {"scenario": direct_fields}

--- a/src/pyetm/utils/excel_utils.py
+++ b/src/pyetm/utils/excel_utils.py
@@ -599,7 +599,7 @@ def apply_field_ordering(df: pd.DataFrame) -> pd.DataFrame:
         "title",
         "description",
         "scenario_id",
-        "template",
+        "template_id",
         "area_code",
         "start_year",
         "end_year",

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -91,7 +91,7 @@ def full_scenario_metadata():
         "metadata": {"foo": "bar"},
         "start_year": 2020,
         "scaling": None,
-        "template": 5,
+        "preset_scenario_id": 5,
         "url": "http://example.com",
     }
 

--- a/tests/models/test_scenario.py
+++ b/tests/models/test_scenario.py
@@ -1072,7 +1072,7 @@ def test_copy_scenario_with_preset_scenario_id(
         "id": 67894,
         "area_code": "nl",
         "end_year": 2050,
-        "template": 12345,
+        "preset_scenario_id": 12345,
     }
 
     monkeypatch.setattr(
@@ -1084,7 +1084,7 @@ def test_copy_scenario_with_preset_scenario_id(
     original = dummy_scenario(12345)
     scenario = original.copy_with_preset()
     assert scenario.id == 67894
-    assert scenario.template == 12345
+    assert scenario.template_id == 12345
     assert len(scenario.warnings) == 0
 
 
@@ -1096,7 +1096,7 @@ def test_copy_scenario_deep_copy_success(
         "id": 67894,
         "area_code": "nl",
         "end_year": 2050,
-        "template": 12345,  # Initially linked
+        "preset_scenario_id": 12345,  # Initially linked
     }
 
     break_link_response = {
@@ -1104,7 +1104,7 @@ def test_copy_scenario_deep_copy_success(
             "id": 67894,
             "area_code": "nl",
             "end_year": 2050,
-            "template": None,  # Link broken
+            "preset_scenario_id": None,  # Link broken
         }
     }
 
@@ -1132,7 +1132,7 @@ def test_copy_scenario_deep_copy_success(
 
     # Verify the scenario is correct and preset link was broken
     assert scenario.id == 67894
-    assert scenario.template is None
+    assert scenario.template_id is None
     assert len(scenario.warnings) == 0
 
 

--- a/tests/models/test_scenario_packer.py
+++ b/tests/models/test_scenario_packer.py
@@ -681,7 +681,7 @@ class TestCreateScenarioFromColumn:
                 "area_code": "nl2015",
                 "end_year": 2050,
                 "private": "yes",
-                "template": "7",
+                "template_id": "7",
                 "source": " src ",
                 "title": " title ",
             }
@@ -708,7 +708,7 @@ class TestCreateScenarioFromColumn:
                 "area_code": "de",
                 "end_year": 2030,
                 "private": 0,
-                "template": None,
+                "template_id": None,
             }
         )
 

--- a/tests/models/test_scenarios_create_many.py
+++ b/tests/models/test_scenarios_create_many.py
@@ -477,3 +477,109 @@ class TestCreateManyErrorHandling:
 
         # Should only have the successful scenarios
         assert len(result.items) == 2
+
+
+class TestCreateManyWithTemplateId:
+    """Test create_many() with template_id parameter."""
+
+    @patch("pyetm.models.scenario.Scenario.from_scenario")
+    @patch("pyetm.models.session.Session.new")
+    def test_create_many_with_template_id_only(
+        self, mock_session_new, mock_from_scenario
+    ):
+        """Test that template_id allows creating scenarios without area_code and end_year."""
+        # Mock Session.new to return mock session
+        mock_session = Mock()
+        mock_session.id = 1
+        mock_session_new.return_value = mock_session
+
+        # Mock Scenario.from_scenario to return mock saved scenario
+        mock_saved = Mock(spec=Scenario)
+        mock_saved.id = 10
+        mock_saved.session = mock_session
+        mock_from_scenario.return_value = mock_saved
+
+        scenarios = Scenarios(client=Mock())
+
+        # Create scenario with only template_id (no area_code or end_year)
+        params: list[ScenarioCreationParams] = [
+            {
+                "title": "Scenario from template",
+                "template_id": 100000,
+            },
+        ]
+
+        result = scenarios.create_many(params)
+
+        # Verify scenario was created successfully
+        assert len(result.items) == 1
+
+        # Verify Session.new was called with None for area_code and end_year
+        # and template_id parameter passed through
+        mock_session_new.assert_called_once_with(None, None, template_id=100000)
+
+    @patch("pyetm.models.scenario.Scenario.from_scenario")
+    @patch("pyetm.models.session.Session.new")
+    def test_create_many_with_template_id_and_explicit_area_year(
+        self, mock_session_new, mock_from_scenario
+    ):
+        """Test that template_id works with explicit area_code and end_year too."""
+        mock_session = Mock()
+        mock_session.id = 1
+        mock_session_new.return_value = mock_session
+
+        mock_saved = Mock(spec=Scenario)
+        mock_saved.session = mock_session
+        mock_from_scenario.return_value = mock_saved
+
+        scenarios = Scenarios(client=Mock())
+
+        # Create scenario with template_id AND explicit area_code/end_year
+        params: list[ScenarioCreationParams] = [
+            {
+                "title": "Scenario with template and overrides",
+                "template_id": 100000,
+                "area_code": "de",
+                "end_year": 2040,
+            },
+        ]
+
+        result = scenarios.create_many(params)
+
+        assert len(result.items) == 1
+
+        # Verify Session.new was called with explicit values
+        mock_session_new.assert_called_once_with("de", 2040, template_id=100000)
+
+    @patch("pyetm.models.scenario.Scenario.from_scenario")
+    @patch("pyetm.models.session.Session.new")
+    def test_create_many_with_default_area_year_and_template(
+        self, mock_session_new, mock_from_scenario
+    ):
+        """Test that default area_code/end_year are used when template_id is present."""
+        mock_session = Mock()
+        mock_session.id = 1
+        mock_session_new.return_value = mock_session
+
+        mock_saved = Mock(spec=Scenario)
+        mock_saved.session = mock_session
+        mock_from_scenario.return_value = mock_saved
+
+        scenarios = Scenarios(client=Mock())
+
+        # Create scenario with template_id and default area_code/end_year
+        params: list[ScenarioCreationParams] = [
+            {
+                "title": "Scenario with defaults and template",
+                "template_id": 100000,
+            },
+        ]
+
+        result = scenarios.create_many(
+            params, area_code="nl", end_year=2050
+        )
+
+        assert len(result.items) == 1
+
+        # Verify Session.new was called with defaults (not None)
+        mock_session_new.assert_called_once_with("nl", 2050, template_id=100000)

--- a/tests/services/scenario_runners/test_create_scenario.py
+++ b/tests/services/scenario_runners/test_create_scenario.py
@@ -156,7 +156,7 @@ def test_create_scenario_all_optional_fields(dummy_client, fake_response):
         "metadata": {"test": "data"},
         "start_year": 2024,
         "scaling": {"factor": 1.5},
-        "template": 123,
+        "template_id": 123,
         "url": "https://example.com",
     }
 
@@ -165,9 +165,9 @@ def test_create_scenario_all_optional_fields(dummy_client, fake_response):
     assert result.data == body
     assert result.errors == []
 
-    # Verify template was transformed to preset_scenario_id
+    # Verify template_id was transformed to preset_scenario_id
     expected_data = scenario_data.copy()
-    expected_data["preset_scenario_id"] = expected_data.pop("template")
+    expected_data["preset_scenario_id"] = expected_data.pop("template_id")
     assert client.calls == [("/scenarios", {"json": {"scenario": expected_data}})]
 
 
@@ -241,3 +241,93 @@ def test_create_scenario_payload_structure(dummy_client, fake_response):
     # Verify the exact payload structure
     expected_call = ("/scenarios", {"json": {"scenario": scenario_data}})
     assert client.calls == [expected_call]
+
+
+def test_create_scenario_with_template_only(dummy_client, fake_response):
+    """Test that scenario can be created with only template_id (no area_code/end_year)."""
+    body = {
+        "id": 99999,
+        "area_code": "nl",  # Inherited from template
+        "end_year": 2050,   # Inherited from template
+        "preset_scenario_id": 100000,
+    }
+    response = fake_response(ok=True, status_code=201, json_data=body)
+    client = dummy_client(response, method="post")
+
+    scenario_data = {"template_id": 100000}  # No area_code or end_year
+
+    result = CreateScenarioRunner.run(client, scenario_data)
+    assert result.success is True
+    assert result.data == body
+    assert result.errors == []
+
+    # Verify template_id was transformed to preset_scenario_id
+    expected_payload = {"scenario": {"preset_scenario_id": 100000}}
+    assert client.calls == [("/scenarios", {"json": expected_payload})]
+
+
+def test_create_scenario_with_template_and_overrides(dummy_client, fake_response):
+    """Test that template_id can be used with explicit area_code/end_year overrides."""
+    body = {
+        "id": 99998,
+        "area_code": "de",
+        "end_year": 2040,
+        "preset_scenario_id": 100000,
+    }
+    response = fake_response(ok=True, status_code=201, json_data=body)
+    client = dummy_client(response, method="post")
+
+    scenario_data = {
+        "template_id": 100000,
+        "area_code": "de",
+        "end_year": 2040,
+    }
+
+    result = CreateScenarioRunner.run(client, scenario_data)
+    assert result.success is True
+    assert result.data == body
+    assert result.errors == []
+
+    # Verify template_id was transformed and area/year included
+    expected_payload = {
+        "scenario": {
+            "preset_scenario_id": 100000,
+            "area_code": "de",
+            "end_year": 2040,
+        }
+    }
+    assert client.calls == [("/scenarios", {"json": expected_payload})]
+
+
+def test_create_scenario_with_template_and_metadata(dummy_client, fake_response):
+    """Test that template_id works with other optional fields like metadata."""
+    body = {
+        "id": 99997,
+        "area_code": "nl",
+        "end_year": 2050,
+        "preset_scenario_id": 100000,
+        "metadata": {"source": "research"},
+    }
+    response = fake_response(ok=True, status_code=201, json_data=body)
+    client = dummy_client(response, method="post")
+
+    scenario_data = {
+        "template_id": 100000,
+        "metadata": {"source": "research"},
+        "private": True,
+    }
+
+    result = CreateScenarioRunner.run(client, scenario_data)
+    assert result.success is True
+    assert result.data == body
+    assert result.errors == []
+
+    # Verify all fields were sent correctly
+    expected_payload = {
+        "scenario": {
+            "preset_scenario_id": 100000,
+            "metadata": {"source": "research"},
+            "private": True,
+        }
+    }
+    assert client.calls == [("/scenarios", {"json": expected_payload})]

--- a/tests/services/scenario_runners/test_update_metadata.py
+++ b/tests/services/scenario_runners/test_update_metadata.py
@@ -295,7 +295,7 @@ def test_update_metadata_runner_meta_keys_constants():
         "metadata",
         "end_year",
         "title",
-        "template",
+        "template_id",
     ]
 
     expected_unsettable_keys = [


### PR DESCRIPTION
#### Context
See #147 - `Scenarios.create_many()` required `area_code` and `end_year` even when `template_id` was provided, despite these values being inherited from the template scenario. The root cause was strict validation logic that did not properly account for the template_id param.

There was also some inconsistency in template/preset/preset_scenario_id/template_id within pyetm. Although some of that is cleared up as part of this PR (`template` vs `template_id`), further improvements could be made to clear up the preset/template inconsistency. This confusion is partially a result of the naming of a 'template' within etengine's API as 'preset_scenario_id', which we had originally seen as potentially confusing for users.

#### Implemented changes
- Updated validation to skip area_code and end_year requirements when template_id is provided
- Improved documentation r.e. `template_id`
- Refactored to standardise methods to use `template_id` rather than `template`. The following changed:
  - Model fields: session.template_id and scenario.template_id (was template)
  - Session.new(): Session.new(template_id=123) (was template=123)
  - Direct runner usage: {"template_id": 123} (was {"template": 123})

#### Related
Closes #147 

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review