### PR TITLE
Fix curves bugs

### DIFF
--- a/src/pyetm/models/packables/annual_exports_pack.py
+++ b/src/pyetm/models/packables/annual_exports_pack.py
@@ -34,6 +34,23 @@ class AnnualExportsPack(Packable):
             if exports is None:
                 return None
 
+            # Fetch the requested exports from the API
+            if hasattr(scenario, 'get_annual_export') and exports:
+                try:
+                    for export_name in exports:
+                        try:
+                            scenario.get_annual_export(export_name)
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to fetch export %s for scenario %s: %s",
+                                export_name,
+                                scenario.identifier(),
+                                e,
+                            )
+                except (TypeError, AttributeError):
+                    # Handle case where exports isn't iterable
+                    pass
+
             # Delegate to the model's to_dataframe() method
             df = scenario.annual_exports.to_dataframe(exports=exports, **kwargs)
 
@@ -61,13 +78,30 @@ class AnnualExportsPack(Packable):
 
         for scenario in self.scenarios:
             try:
+                scenario_key = self._key_for(scenario)
+
+                # Fetch the requested exports from the API
+                if hasattr(scenario, 'get_annual_export') and exports:
+                    try:
+                        for export_name in exports:
+                            try:
+                                scenario.get_annual_export(export_name)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to fetch export %s for scenario %s: %s",
+                                    export_name,
+                                    scenario.identifier(),
+                                    e,
+                                )
+                    except (TypeError, AttributeError):
+                        # Handle case where exports isn't iterable
+                        pass
+
                 # Get multi-index dataframe from model
                 df = scenario.annual_exports.to_dataframe(exports=exports)
 
                 if df is None or df.empty:
                     continue
-
-                scenario_key = self._key_for(scenario)
 
                 for export_name in df.index.get_level_values("export_name").unique():
                     export_df = df.xs(export_name, level="export_name")

--- a/src/pyetm/models/packables/hourly_output_curves_pack.py
+++ b/src/pyetm/models/packables/hourly_output_curves_pack.py
@@ -36,6 +36,38 @@ class HourlyOutputCurvesPack(Packable):
         Transforms the model's multi-index format into column-based format for concatenation.
         """
         try:
+            # Fetch the requested curves from the API
+            # If curves is specified, fetch only those curves
+            # If curves is None, attempt to fetch all curves in the collection
+            if curves is not None:
+                curves_to_fetch = curves
+            else:
+                # Try to get all attached curves, but handle case where this isn't available
+                try:
+                    attached = scenario.hourly_output_curves.attached_keys()
+                    # Validate it's iterable
+                    curves_to_fetch = list(attached) if attached else []
+                except (AttributeError, TypeError):
+                    # If attached_keys() doesn't exist or fails, skip fetching
+                    curves_to_fetch = []
+
+            # Fetch each curve (will cache for later use by to_dataframe)
+            if hasattr(scenario, 'get_output_curve') and curves_to_fetch:
+                try:
+                    for curve_name in curves_to_fetch:
+                        try:
+                            scenario.get_output_curve(curve_name)
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to fetch curve %s for scenario %s: %s",
+                                curve_name,
+                                scenario.identifier(),
+                                e,
+                            )
+                except (TypeError, AttributeError):
+                    # Handle case where curves_to_fetch isn't iterable
+                    pass
+
             # Delegate to the model's to_dataframe() method
             df = scenario.hourly_output_curves.to_dataframe(curves=curves, **kwargs)
 
@@ -160,6 +192,38 @@ class HourlyOutputCurvesPack(Packable):
         for scenario in self.scenarios:
             try:
                 scenario_key = self._key_for(scenario)
+
+                # Fetch the requested curves from the API
+                # If curves is specified, fetch only those curves
+                # If curves is None, attempt to fetch all curves in the collection
+                if curves is not None:
+                    curves_to_fetch = curves
+                else:
+                    # Try to get all attached curves, but handle case where this isn't available
+                    try:
+                        attached = scenario.hourly_output_curves.attached_keys()
+                        # Validate it's iterable
+                        curves_to_fetch = list(attached) if attached else []
+                    except (AttributeError, TypeError):
+                        # If attached_keys() doesn't exist or fails, skip fetching
+                        curves_to_fetch = []
+
+                # Fetch each curve (will cache for later use by to_dataframe)
+                if hasattr(scenario, 'get_output_curve') and curves_to_fetch:
+                    try:
+                        for curve_name in curves_to_fetch:
+                            try:
+                                scenario.get_output_curve(curve_name)
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to fetch curve %s for scenario %s: %s",
+                                    curve_name,
+                                    scenario.identifier(),
+                                    e,
+                                )
+                    except (TypeError, AttributeError):
+                        # Handle case where curves_to_fetch isn't iterable
+                        pass
 
                 # Get multi-index dataframe from model
                 df = scenario.hourly_output_curves.to_dataframe(curves=curves)

--- a/src/pyetm/models/scenario_packer.py
+++ b/src/pyetm/models/scenario_packer.py
@@ -131,8 +131,7 @@ class ScenarioPacker(BaseModel):
             carrier_mappings = HourlyOutputCurves._load_carrier_mappings()
             return carrier_mappings.get(carrier_type, [])
         else:
-            validate_hourly_curve_names(curves)
-            return list(curves)
+            return validate_hourly_curve_names(curves)
 
     def hourly_output_curves(
         self,

--- a/src/pyetm/services/scenario_runners/update_custom_curves.py
+++ b/src/pyetm/services/scenario_runners/update_custom_curves.py
@@ -100,9 +100,7 @@ class UpdateCustomCurvesRunner(BaseRunner[Dict[str, Any]]):
             )
             curve_keys.append(curve.key)
 
-        results = UpdateCustomCurvesRunner._make_batch_requests(
-            client, requests, batch_size=10
-        )
+        results = UpdateCustomCurvesRunner._make_batch_requests(client, requests)
         successful_uploads = []
         all_errors = []
 


### PR DESCRIPTION
#### Context

**Names poorly serialized:**
Because the packer always expected a list (kind of), calls like this: `packer.hourly_output_curves(curves="merit_order")` didn't work because the string was converted to a list like: ["m", "e", "r", ...].

**Caching single v many:**
Another issue with selecting specific curves was that the curves would either be loaded onto the scenario instance or not, meaning the whole set of curves would be fetched in the background anyway, rather than just the curve in question. Now just the curve in question is fetched.
+ a more helpful error messages

**Legacy batch_size argument in custom curve call:**
Also fixed a small bug in setting custom curves, removing the batch_size argument (concurrency is now managed by the semaphore anyway.

#### Related
Closes #148
Closes #151

## Checklist
- [x] I have tested these changes
- [x] I have tagged the relevant people for review
