### PR TITLE
SSL Configuration via env / settings for aiohttp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,18 +23,18 @@ ENVIRONMENT=pro
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
 
-# Proxy Settings (optional)
-# Never commit authenticated proxy URLs to version control!
-# PROXY_SERVERS_HTTP=http://proxy.example.com:8080
-# PROXY_SERVERS_HTTPS=http://secureproxy.example.com:8080
-
 # SSL/TLS Settings (optional)
 # SSL certificate verification (default: true)
 # Set to false ONLY for testing with self-signed certificates - NOT for production!
 # SSL_VERIFY=true
 
-# Trust system environment proxy settings (default: false)
+# Trust environment proxy settings (default: false)
 # When true, respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables
+# These can be set in this .env file or as system environment variables:
+# HTTP_PROXY=http://proxy.example.com:8080
+# HTTPS_PROXY=http://secureproxy.example.com:8080
+# NO_PROXY=localhost,127.0.0.1,.local
+# Then enable proxy support:
 # TRUST_ENV=false
 
 # Custom CA certificate bundle path (optional)

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,20 @@ LOG_LEVEL=INFO
 # PROXY_SERVERS_HTTP=http://proxy.example.com:8080
 # PROXY_SERVERS_HTTPS=http://secureproxy.example.com:8080
 
+# SSL/TLS Settings (optional)
+# SSL certificate verification (default: true)
+# Set to false ONLY for testing with self-signed certificates - NOT for production!
+# SSL_VERIFY=true
+
+# Trust system environment proxy settings (default: false)
+# When true, respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables
+# TRUST_ENV=false
+
+# Custom CA certificate bundle path (optional)
+# Useful for corporate environments with internal Certificate Authorities
+# Example: /path/to/custom-ca-bundle.crt
+# SSL_CERT_PATH=
+
 # CSV File Settings
 # CSV separator character (default: ,)
 CSV_SEPARATOR=,

--- a/src/pyetm/clients/base_client.py
+++ b/src/pyetm/clients/base_client.py
@@ -26,9 +26,13 @@ class BaseClient(metaclass=SingletonMeta):
             base_url (Optional[str]): Base URL for API requests. If None, uses the
                 base URL from application settings.
         """
+        settings = get_settings()
         self.session = ETMSession(
-            base_url=base_url or get_settings().base_url,
-            token=token or get_settings().etm_api_token,
+            base_url=base_url or settings.base_url,
+            token=token or settings.etm_api_token,
+            ssl_verify=settings.ssl_verify,
+            trust_env=settings.trust_env,
+            ssl_cert_path=settings.ssl_cert_path,
         )
 
     def close(self):

--- a/src/pyetm/clients/session.py
+++ b/src/pyetm/clients/session.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import ssl
 import threading
+from pathlib import Path
 from typing import Optional, Dict, Any
 from pydantic import BaseModel
 
@@ -99,7 +101,14 @@ class ETMResponse(BaseModel):
 class ETMSession:
     """Modern async session for ETM API interactions."""
 
-    def __init__(self, base_url: Optional[str] = None, token: Optional[str] = None):
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        ssl_verify: Optional[bool] = None,
+        trust_env: Optional[bool] = None,
+        ssl_cert_path: Optional[Path] = None,
+    ):
         self.base_url = str(base_url or get_settings().base_url).rstrip("/")
         self.token = token or get_settings().etm_api_token
         self.headers = {
@@ -107,6 +116,12 @@ class ETMSession:
             "Accept": "application/json",
         }
         self.proxies = get_settings().proxy_servers or {}
+
+        # SSL configuration
+        settings = get_settings()
+        self.ssl_verify = ssl_verify if ssl_verify is not None else settings.ssl_verify
+        self.trust_env = trust_env if trust_env is not None else settings.trust_env
+        self.ssl_cert_path = ssl_cert_path or settings.ssl_cert_path
 
         self._session: Optional[aiohttp.ClientSession] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -137,18 +152,32 @@ class ETMSession:
             future.result()
 
     async def _create_session(self):
-        """Create aiohttp session."""
+        """Create aiohttp session with SSL configuration."""
         connector_kwargs = {
             "limit": 10,
             "limit_per_host": 2,
             "keepalive_timeout": 120,
         }
 
+        # Configure SSL verification
+        ssl_context: Optional[ssl.SSLContext | bool] = None
+        if not self.ssl_verify:
+            # Disable SSL verification (for testing with self-signed certs)
+            ssl_context = False
+        elif self.ssl_cert_path:
+            # Use custom CA certificate bundle
+            ssl_context = ssl.create_default_context(cafile=str(self.ssl_cert_path))
+        # else: ssl_context remains None, which uses Python's default SSL verification
+
+        connector_kwargs["ssl"] = ssl_context
         connector = aiohttp.TCPConnector(**connector_kwargs)
         timeout = aiohttp.ClientTimeout(total=120, connect=120)
 
         self._session = aiohttp.ClientSession(
-            headers=self.headers, connector=connector, timeout=timeout
+            headers=self.headers,
+            connector=connector,
+            timeout=timeout,
+            trust_env=self.trust_env,
         )
 
     def request(self, method: str, url: str, **kwargs) -> ETMResponse:

--- a/src/pyetm/clients/session.py
+++ b/src/pyetm/clients/session.py
@@ -115,7 +115,6 @@ class ETMSession:
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json",
         }
-        self.proxies = get_settings().proxy_servers or {}
 
         # SSL configuration
         settings = get_settings()
@@ -270,11 +269,6 @@ class ETMSession:
             request_kwargs["params"] = kwargs["params"]
         if "data" in kwargs:
             request_kwargs["data"] = kwargs["data"]
-
-        if self.proxies:
-            request_kwargs["proxy"] = self.proxies.get(
-                "http", self.proxies.get("https")
-            )
 
         if "headers" in kwargs:
             headers = dict(self.headers)

--- a/src/pyetm/config/settings.py
+++ b/src/pyetm/config/settings.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 import tempfile
 from typing import Optional, ClassVar, List, Annotated
-from pydantic import Field, ValidationError, HttpUrl, field_validator
+from pydantic import Field, ValidationError, HttpUrl, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -42,6 +42,18 @@ class AppConfig(BaseSettings):
         None,
         description="HTTPS proxy server URL",
     )
+    ssl_verify: bool = Field(
+        True,
+        description="Verify SSL certificates (set to False only for testing with self-signed certificates)",
+    )
+    trust_env: bool = Field(
+        False,
+        description="Trust system environment proxy settings (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)",
+    )
+    ssl_cert_path: Optional[Path] = Field(
+        None,
+        description="Path to custom CA certificate bundle for SSL verification",
+    )
     csv_separator: str = Field(
         ",",
         description="CSV file separator character",
@@ -59,6 +71,16 @@ class AppConfig(BaseSettings):
     )
 
     temp_folder: Optional[Path] = Path(tempfile.gettempdir()) / "pyetm"
+
+    @model_validator(mode="after")
+    def validate_ssl_cert_path(self):
+        """Validate that SSL cert path exists if provided."""
+        if self.ssl_cert_path is not None and not self.ssl_cert_path.exists():
+            raise ValueError(
+                f"SSL certificate file not found: {self.ssl_cert_path}. "
+                f"Please provide a valid path to a CA certificate bundle."
+            )
+        return self
 
     @field_validator("etm_api_token")
     @classmethod

--- a/src/pyetm/config/settings.py
+++ b/src/pyetm/config/settings.py
@@ -34,14 +34,6 @@ class AppConfig(BaseSettings):
         description="App logging level",
     )
 
-    proxy_servers_http: Optional[str] = Field(
-        None,
-        description="HTTP proxy server URL",
-    )
-    proxy_servers_https: Optional[str] = Field(
-        None,
-        description="HTTPS proxy server URL",
-    )
     ssl_verify: bool = Field(
         True,
         description="Verify SSL certificates (set to False only for testing with self-signed certificates)",
@@ -126,15 +118,6 @@ class AppConfig(BaseSettings):
         folder.mkdir(parents=True, exist_ok=True)
         return folder
 
-    @property
-    def proxy_servers(self) -> dict[str, str]:
-        """Return proxy servers as a dictionary"""
-        proxies = {}
-        if self.proxy_servers_http:
-            proxies["http"] = self.proxy_servers_http
-        if self.proxy_servers_https:
-            proxies["https"] = self.proxy_servers_https
-        return proxies
 
 
 def get_settings() -> AppConfig:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -21,6 +21,9 @@ def clean_settings_env(monkeypatch, tmp_path):
         "DECIMAL_SEPARATOR",
         "PROXY_SERVERS_HTTP",
         "PROXY_SERVERS_HTTPS",
+        "SSL_VERIFY",
+        "TRUST_ENV",
+        "SSL_CERT_PATH",
     ]
     for var in etm_vars:
         monkeypatch.delenv(var, raising=False)
@@ -289,3 +292,115 @@ PROXY_SERVERS_HTTP="http://user:pass@proxy.example.com:8080"'''
     assert config.log_level == "DEBUG WITH SPACES"
     assert config.csv_separator == ";"
     assert config.proxy_servers_http == "http://user:pass@proxy.example.com:8080"
+
+
+# Test SSL default values
+def test_ssl_default_values(clean_settings_env):
+    env_file = clean_settings_env
+    write_env_file(env_file, {"ETM_API_TOKEN": "etm_valid.looking.token"})
+
+    config = AppConfig()
+
+    assert config.ssl_verify is True  # Should verify by default
+    assert config.trust_env is False  # Should not trust env by default
+    assert config.ssl_cert_path is None  # No custom cert by default
+
+
+# Test SSL verification can be disabled
+def test_ssl_verify_disabled(clean_settings_env):
+    env_file = clean_settings_env
+    write_env_file(
+        env_file,
+        {
+            "ETM_API_TOKEN": "etm_valid.looking.token",
+            "SSL_VERIFY": "false",
+        },
+    )
+
+    config = AppConfig()
+
+    assert config.ssl_verify is False
+
+
+# Test trust_env can be enabled
+def test_trust_env_enabled(clean_settings_env):
+    env_file = clean_settings_env
+    write_env_file(
+        env_file,
+        {
+            "ETM_API_TOKEN": "etm_valid.looking.token",
+            "TRUST_ENV": "true",
+        },
+    )
+
+    config = AppConfig()
+
+    assert config.trust_env is True
+
+
+# Test custom SSL certificate path
+def test_ssl_cert_path_valid(clean_settings_env, tmp_path):
+    env_file = clean_settings_env
+
+    # Create a dummy cert file
+    cert_file = tmp_path / "ca-bundle.crt"
+    cert_file.write_text("-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----")
+
+    write_env_file(
+        env_file,
+        {
+            "ETM_API_TOKEN": "etm_valid.looking.token",
+            "SSL_CERT_PATH": str(cert_file),
+        },
+    )
+
+    config = AppConfig()
+
+    assert config.ssl_cert_path == cert_file
+    assert config.ssl_cert_path.exists()
+
+
+# Test invalid SSL certificate path raises error
+def test_ssl_cert_path_invalid_raises_error(clean_settings_env, tmp_path):
+    env_file = clean_settings_env
+
+    # Use a path that doesn't exist
+    fake_cert_path = tmp_path / "nonexistent.crt"
+
+    write_env_file(
+        env_file,
+        {
+            "ETM_API_TOKEN": "etm_valid.looking.token",
+            "SSL_CERT_PATH": str(fake_cert_path),
+        },
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        AppConfig()
+
+    errs = excinfo.value.errors()
+    assert any("SSL certificate file not found" in str(err) for err in errs)
+
+
+# Test all SSL options together
+def test_all_ssl_options_together(clean_settings_env, tmp_path):
+    env_file = clean_settings_env
+
+    cert_file = tmp_path / "custom-ca.crt"
+    cert_file.write_text("-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----")
+
+    write_env_file(
+        env_file,
+        {
+            "ETM_API_TOKEN": "etm_valid.looking.token",
+            "SSL_VERIFY": "true",
+            "TRUST_ENV": "true",
+            "SSL_CERT_PATH": str(cert_file),
+        },
+    )
+
+    config = AppConfig()
+
+    assert config.ssl_verify is True
+    assert config.trust_env is True
+    assert config.ssl_cert_path == cert_file

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,8 +19,6 @@ def clean_settings_env(monkeypatch, tmp_path):
         "ENVIRONMENT",
         "CSV_SEPARATOR",
         "DECIMAL_SEPARATOR",
-        "PROXY_SERVERS_HTTP",
-        "PROXY_SERVERS_HTTPS",
         "SSL_VERIFY",
         "TRUST_ENV",
         "SSL_CERT_PATH",
@@ -102,29 +100,6 @@ def test_base_url_inference_from_environment(clean_settings_env):
     )
 
 
-# Test proxy servers configuration
-def test_proxy_servers_configuration(clean_settings_env):
-    env_file = clean_settings_env
-    write_env_file(
-        env_file,
-        {
-            "ETM_API_TOKEN": "etm_valid.looking.token",
-            "PROXY_SERVERS_HTTP": "http://proxy.example.com:8080",
-            "PROXY_SERVERS_HTTPS": "https://secure.proxy.com:8080",
-        },
-    )
-
-    config = AppConfig()
-
-    assert config.proxy_servers_http == "http://proxy.example.com:8080"
-    assert config.proxy_servers_https == "https://secure.proxy.com:8080"
-
-    # Test backward compatibility property
-    proxy_dict = config.proxy_servers
-    assert proxy_dict["http"] == "http://proxy.example.com:8080"
-    assert proxy_dict["https"] == "https://secure.proxy.com:8080"
-
-
 # Test no .env file, only environment variables
 def test_no_env_file_uses_env_vars_and_defaults(clean_settings_env, monkeypatch):
     # Don't create the env_file, just set environment variable
@@ -167,8 +142,6 @@ def test_default_values(clean_settings_env):
     assert config.log_level == "INFO"
     assert config.csv_separator == ","
     assert config.decimal_separator == "."
-    assert config.proxy_servers_http is None
-    assert config.proxy_servers_https is None
     assert config.base_url == HttpUrl("https://engine.energytransitionmodel.com/api/v3")
 
 
@@ -282,8 +255,7 @@ def test_quoted_values_in_env_file(clean_settings_env):
     env_file = clean_settings_env
     content = '''ETM_API_TOKEN=etm_valid.looking.token
 LOG_LEVEL="DEBUG WITH SPACES"
-CSV_SEPARATOR=";"
-PROXY_SERVERS_HTTP="http://user:pass@proxy.example.com:8080"'''
+CSV_SEPARATOR=";"'''
     env_file.write_text(content)
 
     config = AppConfig()
@@ -291,7 +263,6 @@ PROXY_SERVERS_HTTP="http://user:pass@proxy.example.com:8080"'''
     assert config.etm_api_token == "etm_valid.looking.token"
     assert config.log_level == "DEBUG WITH SPACES"
     assert config.csv_separator == ";"
-    assert config.proxy_servers_http == "http://user:pass@proxy.example.com:8080"
 
 
 # Test SSL default values


### PR DESCRIPTION
#### Context
Users requested the same ssl options for aiohttp as were present on the previous pyetm. These options allow you to use custom certs, disable ssl for testing environments or enable system proxies. Because this is an alternative proxy method that worked previously for users of pyetm (environment level rather than session level), I have also retired the previous proxy-ing approach in favour of this approach.

**Note:** I could test that the variables are loaded correctly, but I'm not exactly sure how to test custom certificates etc. The proof may need to be in whether it works for our users.

#### How it works

1. User configures via .env file (or system environment variables)
2. AppConfig loads and validates settings (with path validation for SSL_CERT_PATH)
3. BaseClient passes SSL settings to ETMSession
4. ETMSession creates appropriate SSL context:
   - ssl=False (bool) - Disables verification entirely
   - ssl=SSLContext - Custom context with CA bundle
   - ssl=None (default) - Standard Python CA verification
5. aiohttp handles all SSL verification and proxy routing

#### What actually are the options in the env?
This will need to be added to the readme.md when it is updated shortly

- SSL_VERIFY: "Should I check if the server's certificate is legit?" (default: yes)
- TRUST_ENV: "Should I use proxy settings from environment variables?" (default: no)
- HTTP_PROXY: "Which proxy server should I use for HTTP?" (only if TRUST_ENV=true)
- HTTPS_PROXY: "Which proxy server should I use for HTTPS?" (only if TRUST_ENV=true)
- NO_PROXY: "Which hosts should skip the proxy?" (only if TRUST_ENV=true)
- SSL_CERT_PATH: "Where's the file with extra trusted certificates?"

## Checklist
- [x] I have tested these changes (little test included for settings)
- [x] I have updated documentation as needed (.env.example has the documentation for now - I am going to rewrite the readme in general in another PR)
- [x] I have tagged the relevant people for review
