### PR TITLE
Fix identifier hierarchy

### DIFF
--- a/src/pyetm/models/scenario.py
+++ b/src/pyetm/models/scenario.py
@@ -480,8 +480,16 @@ class Scenario(Base):
         self.session.show_all_warnings()
 
     def identifier(self) -> Union[str, int]:
-        """Get identifier (short_name, title, or id) from the underlying session."""
-        return self.session.identifier()
+        """Get identifier in priority order: saved title, short_name, session title, saved id, session id."""
+        if self.title:
+            return self.title
+        if self.session.short_name:
+            return self.session.short_name
+        if self.session.title:
+            return self.session.title
+        if self.id:
+            return self.id
+        return self.session.id
 
     def set_short_name(self, short_name: str) -> None:
         """Set short name on the underlying session."""

--- a/src/pyetm/models/session.py
+++ b/src/pyetm/models/session.py
@@ -360,7 +360,7 @@ class Session(Base):
                 if k not in info:
                     info[k] = v
 
-        col_name = self.identifier() if self.identifier() is not None else self.id
+        col_name = str(self.identifier())
         return pd.DataFrame.from_dict(info, orient="index", columns=[col_name])
 
     def set_short_name(self, short_name: str):

--- a/tests/models/test_saved_scenario.py
+++ b/tests/models/test_saved_scenario.py
@@ -491,9 +491,10 @@ def test_saved_scenario_delegation_transparent_to_user(saved_scenario):
 
     saved_scenario._scenario_session = mock_session
 
-    # User code should work identically whether they have a Scenario or SavedScenario
+    # SavedScenario has its own identifier logic that prioritizes saved title
+    # This saved_scenario fixture has title="My Saved Scenario", so that takes priority
     identifier = saved_scenario.identifier()
-    assert identifier == "test_scenario"
+    assert identifier == "My Saved Scenario"
 
     # Both should support the same operations
     saved_scenario.update_user_values({"test": 123})
@@ -679,3 +680,107 @@ def test_saved_scenario_interpolate_rejects_different_area_codes():
 
     with pytest.raises(ValueError, match="All sessions must have the same area_code"):
         Scenario.interpolate([saved_nl, saved_de], 2040)
+
+
+# --- Identifier Resolution Tests --- #
+
+
+def test_identifier_prioritizes_saved_title():
+    """Test identifier returns saved scenario title when available."""
+    saved = Scenario(id=1001, scenario_id=12345, title="Saved Title")
+    # Mock session with short_name, title, and id
+    saved._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050, title="Session Title", short_name="short"
+    )
+
+    assert saved.identifier() == "Saved Title"
+
+
+def test_identifier_falls_back_to_short_name():
+    """Test identifier returns short_name when saved title is not available."""
+    saved = Scenario(id=1001, scenario_id=12345, title="")
+    # Mock session with short_name
+    saved._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050, title="Session Title", short_name="short"
+    )
+
+    assert saved.identifier() == "short"
+
+
+def test_identifier_falls_back_to_session_title():
+    """Test identifier returns session title when saved title and short_name not available."""
+    saved = Scenario(id=1001, scenario_id=12345, title="")
+    # Mock session with only title
+    saved._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050, title="Session Title"
+    )
+
+    assert saved.identifier() == "Session Title"
+
+
+def test_identifier_falls_back_to_saved_id():
+    """Test identifier returns saved scenario id when saved title, short_name, and session title not available."""
+    saved = Scenario(id=1001, scenario_id=12345, title="")
+    # Mock session with no title or short_name
+    saved._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050
+    )
+
+    assert saved.identifier() == 1001
+
+
+def test_identifier_falls_back_to_session_id():
+    """Test identifier returns session id as final fallback."""
+    saved = Scenario(id=None, scenario_id=12345, title="")
+    # Mock session with no title or short_name
+    saved._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050
+    )
+
+    assert saved.identifier() == 12345
+
+
+def test_identifier_resolution_order_complete():
+    """Test complete identifier resolution order with all properties present."""
+    # Test 1: When all properties are present, saved title should win
+    saved1 = Scenario(id=1001, scenario_id=12345, title="Saved Title")
+    saved1._scenario_session = Session(
+        id=12345,
+        area_code="nl",
+        end_year=2050,
+        title="Session Title",
+        short_name="short"
+    )
+    assert saved1.identifier() == "Saved Title"
+
+    # Test 2: Without saved title, should return short_name
+    saved2 = Scenario(id=1001, scenario_id=12345, title="")
+    saved2._scenario_session = Session(
+        id=12345,
+        area_code="nl",
+        end_year=2050,
+        title="Session Title",
+        short_name="short"
+    )
+    assert saved2.identifier() == "short"
+
+    # Test 3: Without saved title and short_name, should return session title
+    saved3 = Scenario(id=1001, scenario_id=12345, title="")
+    saved3._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050, title="Session Title"
+    )
+    assert saved3.identifier() == "Session Title"
+
+    # Test 4: Without saved title, short_name, and session title, should return saved id
+    saved4 = Scenario(id=1001, scenario_id=12345, title="")
+    saved4._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050
+    )
+    assert saved4.identifier() == 1001
+
+    # Test 5: Without any identifier except session id, should return session id
+    saved5 = Scenario(id=None, scenario_id=12345, title="")
+    saved5._scenario_session = Session(
+        id=12345, area_code="nl", end_year=2050
+    )
+    assert saved5.identifier() == 12345

--- a/tests/models/test_scenario.py
+++ b/tests/models/test_scenario.py
@@ -658,7 +658,7 @@ def test_to_dataframe(scenario):
     scenario = Session(id=scenario.id, area_code="nl2019", end_year=2050)
     dataframe = scenario.to_dataframe()
 
-    assert dataframe[scenario.id]["end_year"] == 2050
+    assert dataframe[str(scenario.identifier())]["end_year"] == 2050
 
 
 # ------ Warnings tests ------ #
@@ -1198,8 +1198,6 @@ def test_copy_scenario_deep_false_doesnt_break_link(
     assert scenario.id == 67896
 
 
-
-
 # ------ interpolate ------ #
 
 
@@ -1424,7 +1422,9 @@ def test_get_annual_exports_mixed_valid_and_invalid(scenario):
     assert "bad_export" in error_message
 
 
-def test_get_annual_exports_auto_converts_single_string(monkeypatch, scenario, ok_service_result):
+def test_get_annual_exports_auto_converts_single_string(
+    monkeypatch, scenario, ok_service_result
+):
     """Test that get_annual_exports auto-converts single string to list"""
     # Mock the retrieve_multiple method to capture the arguments
     calls = []
@@ -1438,6 +1438,7 @@ def test_get_annual_exports_auto_converts_single_string(monkeypatch, scenario, o
 
     def mock_session_get_annual_exports(self, export_names):
         from pyetm.validators import validate_export_names
+
         validated_names = validate_export_names(export_names)
         calls.append(validated_names)
         return {}


### PR DESCRIPTION
#### Context
New priority order for identifier, taking into account the saved scenario title and saved scenario id, rather than just delegating to the session identifier. The new order is:
1.     Saved scenario title (self.title)
2.    Short name (session.short_name)
3.    Session title (session.title)
4.    Saved scenario id (self.id)
5.    Session id (session.id)

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
