### PR TITLE
Handle curves and exports via the metadata endpoint

### DIFF
--- a/docs/user-guide/excel.md
+++ b/docs/user-guide/excel.md
@@ -86,7 +86,10 @@ The `hourly_curves` field has three modes:
 - `methane` - Maps to ETM: `network_gas_profiles`
 
 **Available curve names** (can be specified individually):
-`electricity_profiles`, `electricity_capacities`, `electricity_price`, `district_heating_profiles`, `district_heating_capacities`, `agriculture_heat`, `household_heat`, `buildings_heat`, `hydrogen_profiles`, `hydrogen_capacities`, `network_gas_profiles`, `network_gas_capacities`, `residual_load`, `hydrogen_integral_cost`
+`electricity_profiles`, `electricity_price`, `district_heating_profiles`, `agriculture_heat`, `household_heat`, `buildings_heat`, `hydrogen_profiles`, `network_gas_profiles`, `residual_load`, `hydrogen_integral_cost`
+
+!!! note "Capacities are annual exports"
+    Capacity outputs (`electricity_capacities`, `district_heating_capacities`, `hydrogen_capacities`, `network_gas_capacities`) are annual exports, not hourly curves — select them via the `annual_exports` field below.
 
 !!! note "Deprecated curve names"
     The old curve names (`merit_order`, `heat_network`, `hydrogen`, `network_gas`) are deprecated but still supported with warnings. Please update to use the new names.
@@ -122,7 +125,6 @@ The `annual_exports` field has three modes:
 
 **Available export types**:
 
-- `production_parameters` - Production parameters for technologies
 - `energy_flow` - Energy flow data between nodes
 - `energy_flow_present` - Present-year energy flow data
 - `molecule_flow` - Molecule flow data
@@ -384,7 +386,7 @@ current_config = scenario.get_export_config()
 | `include_input_defaults` | `bool` | Include default input values (not just user-set) |
 | `include_input_min_max` | `bool` | Include min/max bounds for inputs |
 | `hourly_curves` | `List[str]` | Hourly curves for carriers: `"electricity"`, `"heat"`, `"hydrogen"`, `"methane"` |
-| `include_annual_exports` | `List[str]` | Annual exports: `"energy_flow"`, `"sankey"`, `"production_parameters"`, etc. |
+| `include_annual_exports` | `List[str]` | Annual exports: `"energy_flow"`, `"sankey"`, `"storage_parameters"`, `"electricity_capacities"`, etc. |
 
 ## To Excel
 

--- a/docs/user-guide/excel.md
+++ b/docs/user-guide/excel.md
@@ -88,14 +88,8 @@ The `hourly_curves` field has three modes:
 **Available curve names** (can be specified individually):
 `electricity_profiles`, `electricity_price`, `district_heating_profiles`, `agriculture_heat`, `household_heat`, `buildings_heat`, `hydrogen_profiles`, `network_gas_profiles`, `residual_load`, `hydrogen_integral_cost`
 
-!!! note "Capacities are annual exports"
-    Capacity outputs (`electricity_capacities`, `district_heating_capacities`, `hydrogen_capacities`, `network_gas_capacities`) are annual exports, not hourly curves — select them via the `annual_exports` field below.
-
 !!! note "Deprecated curve names"
     The old curve names (`merit_order`, `heat_network`, `hydrogen`, `network_gas`) are deprecated but still supported with warnings. Please update to use the new names.
-
-!!! note "Validation"
-    Invalid carrier or curve names will be filtered out with a warning. Only valid entries will be exported.
 
 #### Annual Exports Options
 

--- a/docs/user-guide/exports.md
+++ b/docs/user-guide/exports.md
@@ -37,9 +37,6 @@ The following curves are available. **Carrier Type Alias** provides a convenient
 !!! note "Deprecated curve names"
     The old curve names (`merit_order`, `heat_network`, `hydrogen`, `network_gas`) are deprecated but still supported with warnings. Please update your code to use the new names (`electricity_profiles`, `district_heating_profiles`, `hydrogen_profiles`, `network_gas_profiles`).
 
-!!! note "Capacities are annual exports"
-    Installed/peak capacity outputs (`electricity_capacities`, `district_heating_capacities`, `hydrogen_capacities`, `network_gas_capacities`) are tables rather than 8760-hour series, so they are [annual exports](#annual-exports), not hourly curves. Fetch them with `scenario.get_annual_export("electricity_capacities")`.
-
 ### Accessing Single Curves
 
 Get a single curve by name or carrier type alias:

--- a/docs/user-guide/exports.md
+++ b/docs/user-guide/exports.md
@@ -9,7 +9,7 @@ For detailed API signatures and parameters, see the [API Reference](../api/index
 The ETM provides two main types of output data:
 
 - **Hourly Output Curves** — 8760-hour resolution data from Merit (electricity) and Fever (heat) calculations
-- **Annual Exports** — Aggregated yearly data including energy flows, production parameters, costs, and sankey diagrams as csvs
+- **Annual Exports** — Aggregated yearly data including energy flows, capacities, costs, storage parameters, and sankey diagrams as csvs
 
 Both types use lazy loading and disk caching for performance.
 
@@ -36,6 +36,9 @@ The following curves are available. **Carrier Type Alias** provides a convenient
 
 !!! note "Deprecated curve names"
     The old curve names (`merit_order`, `heat_network`, `hydrogen`, `network_gas`) are deprecated but still supported with warnings. Please update your code to use the new names (`electricity_profiles`, `district_heating_profiles`, `hydrogen_profiles`, `network_gas_profiles`).
+
+!!! note "Capacities are annual exports"
+    Installed/peak capacity outputs (`electricity_capacities`, `district_heating_capacities`, `hydrogen_capacities`, `network_gas_capacities`) are tables rather than 8760-hour series, so they are [annual exports](#annual-exports), not hourly curves. Fetch them with `scenario.get_annual_export("electricity_capacities")`.
 
 ### Accessing Single Curves
 
@@ -128,7 +131,6 @@ Annual exports provide aggregated yearly data in various formats for analysis an
 
 | Export Name | Description |
 |-------------|-------------|
-| `production_parameters` | Production capacity and utilization |
 | `energy_flow` | Energy flows by carrier (future year) |
 | `energy_flow_present` | Energy flows by carrier (present year) |
 | `molecule_flow` | Molecule/hydrogen flows |
@@ -139,9 +141,6 @@ Annual exports provide aggregated yearly data in various formats for analysis an
 | `district_heating_capacities` | Installed/peak capacity per participant in the heat merit order |
 | `hydrogen_capacities` | Installed/peak capacity for hydrogen participants |
 | `network_gas_capacities` | Installed/peak capacity for network gas participants |
-
-!!! note "Capacity tables and engine version"
-    The four capacity exports are only available on modern engines (`pro`). On the stable `2025-01` tag they do not exist; `get_annual_export()` returns `None` in that case.
 
 ### Basic Access
 
@@ -164,7 +163,7 @@ Retrieve several exports in one call:
 # Get multiple exports
 exports = scenario.get_annual_exports([
     "energy_flow",
-    "production_parameters",
+    "storage_parameters",
     "costs_parameters"
 ])
 
@@ -190,7 +189,7 @@ exports = scenario.annual_exports
 
 # List all available export types
 print(exports.names)
-# ['production_parameters', 'energy_flow', 'energy_flow_present', ...]
+# ['energy_flow', 'energy_flow_present', 'molecule_flow', ...]
 
 # Get cached export (returns None if not yet fetched)
 cached = exports.get("energy_flow")

--- a/src/pyetm/clients/session.py
+++ b/src/pyetm/clients/session.py
@@ -283,6 +283,15 @@ class ETMSession:
             headers.update(kwargs["headers"])
             request_kwargs["headers"] = headers
 
+        if "timeout" in kwargs:
+            timeout = kwargs["timeout"]
+            # Accept a plain number of seconds as well as an aiohttp.ClientTimeout.
+            request_kwargs["timeout"] = (
+                aiohttp.ClientTimeout(total=timeout)
+                if isinstance(timeout, (int, float))
+                else timeout
+            )
+
         return request_kwargs
 
     def close(self) -> None:

--- a/src/pyetm/config/curve_registry.py
+++ b/src/pyetm/config/curve_registry.py
@@ -1,28 +1,33 @@
 """Single source of truth for hourly output curve names.
 
+This registry covers only the **hourly** output cluster — 8760-row curves served from
+``/scenarios/{id}/curves/{wire}.csv``. Capacities are a table shape and belong to the
+**annual** export cluster (``/scenarios/{id}/{name}``); they are handled by the
+AnnualExports model and discovered via ``/exports/metadata``, not here.
+
 etengine renamed the hourly curve endpoints (``merit_order`` -> ``electricity_profiles``,
 ``heat_network`` -> ``district_heating_profiles``, ``hydrogen`` -> ``hydrogen_profiles``,
 ``network_gas`` -> ``network_gas_profiles``) but kept the OLD names as backwards-compatible
 aliases. The old names therefore work on BOTH modern engines (pro) and stable engines
-(2025-01, which only ever had the old names), so pyetm uses them as the on-the-wire name and
-needs no per-engine logic.
+(2025-01, which only ever had the old names), so pyetm sends them as the on-the-wire name
+and needs no per-engine logic.
 
 Each logical curve maps to:
 - ``canonical``: the stable, public key used inside pyetm (cache files, ``curve.key``); the
   modern name.
 - ``wire``: the name sent in the request URL (the universal old name where one exists).
-- ``endpoint``: ``curves`` -> /scenarios/{id}/curves/{name}.csv
+
+This module is the offline fallback for :class:`CurveMetadataService`; the live
+``/curves/metadata`` endpoint is always preferred when reachable.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger("pyetm")
-
-Endpoint = Literal["curves", "export"]
 
 
 @dataclass(frozen=True)
@@ -31,25 +36,27 @@ class CurveSpec:
 
     canonical: str
     wire: str
-    endpoint: Endpoint
     curve_type: str
     carrier: Optional[str] = None
 
 
 _SPECS: tuple[CurveSpec, ...] = (
     # Renamed hourly profile curves: send the universal old name (works on pro + 2025-01)
-    CurveSpec("electricity_profiles", "merit_order", "curves", "merit_curve", carrier="electricity"),
-    CurveSpec("district_heating_profiles", "heat_network", "curves", "load_curve", carrier="heat"),
-    CurveSpec("hydrogen_profiles", "hydrogen", "curves", "reconciliation_curve", carrier="hydrogen"),
-    CurveSpec("network_gas_profiles", "network_gas", "curves", "reconciliation_curve", carrier="methane"),
+    CurveSpec("electricity_profiles", "merit_order", "merit_curve", carrier="electricity"),
+    CurveSpec("district_heating_profiles", "heat_network", "load_curve", carrier="heat"),
+    CurveSpec("hydrogen_profiles", "hydrogen", "reconciliation_curve", carrier="hydrogen"),
+    CurveSpec("network_gas_profiles", "network_gas", "reconciliation_curve", carrier="methane"),
     # Unchanged curves (same name on both engines)
-    CurveSpec("electricity_price", "electricity_price", "curves", "price_curve"),
-    CurveSpec("agriculture_heat", "agriculture_heat", "curves", "merit_curve"),
-    CurveSpec("household_heat", "household_heat", "curves", "fever_curve"),
-    CurveSpec("buildings_heat", "buildings_heat", "curves", "fever_curve"),
-    CurveSpec("residual_load", "residual_load", "curves", "query_curve"),
-    CurveSpec("hydrogen_integral_cost", "hydrogen_integral_cost", "curves", "query_curve"),
+    CurveSpec("electricity_price", "electricity_price", "price_curve"),
+    CurveSpec("agriculture_heat", "agriculture_heat", "merit_curve"),
+    CurveSpec("household_heat", "household_heat", "fever_curve"),
+    CurveSpec("buildings_heat", "buildings_heat", "fever_curve"),
+    CurveSpec("residual_load", "residual_load", "query_curve"),
+    CurveSpec("hydrogen_integral_cost", "hydrogen_integral_cost", "query_curve"),
 )
+# Capacities are annual exports, not hourly curves (table shape, served from the
+# /exports endpoint). They live in the annual-export cluster — see
+# CurveMetadataService._DEFAULT_EXPORTS and the AnnualExports model.
 
 _BY_CANONICAL: dict[str, CurveSpec] = {s.canonical: s for s in _SPECS}
 
@@ -66,6 +73,15 @@ _DEPRECATED_ALIASES: dict[str, str] = {
 def canonical_names() -> list[str]:
     """Canonical key for every registered curve."""
     return [s.canonical for s in _SPECS]
+
+
+def default_curve_metadata() -> list[dict[str, str]]:
+    """Offline fallback metadata for every registered curve.
+
+    Mirrors the shape of ETEngine's ``/curves/metadata`` response so
+    :class:`CurveMetadataService` can fall back to it when the endpoint is unavailable.
+    """
+    return [{"name": s.canonical, "type": s.curve_type, "description": ""} for s in _SPECS]
 
 
 def accept_alias(name: str) -> str:
@@ -100,13 +116,11 @@ def carrier_to_canonical() -> dict[str, str]:
 
 
 def build_path(session_id: Any, name: str) -> str:
-    """Request path for an output curve / capacity export.
+    """Request path for an output curve or capacity on the unified curves route.
 
-    ``curves``  -> /scenarios/{id}/curves/{wire_name}.csv
-    ``export``  -> /scenarios/{id}/{name}   (scenario-member, mirrors fetch_annual_exports)
+    ``/scenarios/{id}/curves/{wire_name}.csv`` — renamed curves send their universal old
+    name; everything else sends its own name.
     """
     spec = get_spec(name)
-    if spec and spec.endpoint == "export":
-        return f"/scenarios/{session_id}/{spec.canonical}"
     wire = spec.wire if spec else name
     return f"/scenarios/{session_id}/curves/{wire}.csv"

--- a/src/pyetm/config/settings.py
+++ b/src/pyetm/config/settings.py
@@ -72,6 +72,17 @@ class AppConfig(BaseSettings):
         ".",
         description="Decimal separator character",
     )
+    metadata_timeout: float = Field(
+        5.0,
+        description="Timeout (in seconds) for curve/export metadata requests to ETEngine.",
+    )
+    metadata_cache_ttl: float = Field(
+        3600.0,
+        description=(
+            "Seconds before in-memory curve/export metadata is refetched. "
+            "Set to 0 to cache for the whole process lifetime."
+        ),
+    )
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         case_sensitive=False,
@@ -197,6 +208,19 @@ def reload_configuration() -> None:
     # Import here to avoid circular dependency
     from pyetm.models.error_policy import get_error_policy
     get_error_policy.cache_clear()
+
+    # Rebuild the shared client so a changed base_url/SSL/token takes effect, and
+    # drop cached metadata so a new environment is not served stale curve names.
+    from pyetm.clients.base_client import get_client
+    if get_client.cache_info().currsize:
+        try:
+            get_client().close()
+        except Exception:
+            logger.debug("Failed to close cached client during reload", exc_info=True)
+    get_client.cache_clear()
+
+    from pyetm.services.curve_metadata_service import CurveMetadataService
+    CurveMetadataService.clear_cache()
 
 
 def _infer_base_url_from_env(environment: str) -> str:

--- a/src/pyetm/models/annual_exports.py
+++ b/src/pyetm/models/annual_exports.py
@@ -10,21 +10,7 @@ from pyetm.models.base import Base
 from pyetm.services.scenario_runners.fetch_annual_exports import (
     DownloadAnnualExportRunner,
 )
-
-# Available annual export types - see https://docs.energytransitionmodel.com/api/exports
-ANNUAL_EXPORT_TYPES = [
-    "production_parameters",
-    "energy_flow",
-    "energy_flow_present",
-    "molecule_flow",
-    "sankey",
-    "storage_parameters",
-    "costs_parameters",
-    "electricity_capacities",
-    "district_heating_capacities",
-    "hydrogen_capacities",
-    "network_gas_capacities",
-]
+from pyetm.services.curve_metadata_service import CurveMetadataService
 
 
 class AnnualExportError(Exception):
@@ -98,9 +84,10 @@ class AnnualExport(Base):
     @classmethod
     def from_name(cls, name: str) -> "AnnualExport":
         """Create an AnnualExport instance for a given export type"""
-        if name not in ANNUAL_EXPORT_TYPES:
+        valid_export_names = CurveMetadataService.get_export_names()
+        if name not in valid_export_names:
             export = cls(name=name)
-            valid_types = ", ".join(ANNUAL_EXPORT_TYPES)
+            valid_types = ", ".join(valid_export_names)
             export.add_warning(
                 "name",
                 f"Unknown export type '{name}'. Valid types: {valid_types}",
@@ -238,5 +225,6 @@ class AnnualExports(Base):
 
     @classmethod
     def create_empty_collection(cls) -> "AnnualExports":
-        exports = {name: AnnualExport.from_name(name) for name in ANNUAL_EXPORT_TYPES}
+        export_names = CurveMetadataService.get_export_names()
+        exports = {name: AnnualExport.from_name(name) for name in export_names}
         return cls(exports=exports)

--- a/src/pyetm/models/hourly_output_curves.py
+++ b/src/pyetm/models/hourly_output_curves.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any, Optional
 import os
 
+import yaml
+
 logger = logging.getLogger(__name__)
 from pyetm.clients import BaseClient, get_client
 from pyetm.models.base import Base
@@ -18,6 +20,7 @@ from pyetm.services.scenario_runners.fetch_hourly_output_curves import (
     DownloadHourlyOutputCurveRunner,
     FetchAllHourlyOutputCurvesRunner,
 )
+from pyetm.services.curve_metadata_service import CurveMetadataService
 
 
 # Small LRU cache for reading CSVs from disk. Uses mtime to invalidate when file changes.
@@ -435,8 +438,17 @@ class HourlyOutputCurves(Base):
 
     @staticmethod
     def _infer_curve_type(curve_name: str) -> str:
-        """Infer curve type from curve name (accepts legacy/old names)."""
-        return registry.curve_type_for(curve_name)
+        """Infer curve type from curve name using metadata service."""
+        # Resolve any legacy/old name to its canonical key first
+        curve_name = registry.accept_alias(curve_name)
+
+        # Try to get type from metadata service
+        curve_type = CurveMetadataService.get_curve_type(curve_name)
+        if curve_type:
+            return curve_type
+
+        # Fallback to generic type if not found
+        return "output_curve"
 
     @classmethod
     def fetch_all(
@@ -507,12 +519,8 @@ class HourlyOutputCurves(Base):
         Create a collection with all known hourly output curve types but no data.
         This allows is_attached() to work before data is retrieved.
         """
-        from pyetm.services.scenario_runners.fetch_hourly_output_curves import (
-            FetchAllHourlyOutputCurvesRunner,
-        )
-
         curves_list = []
-        for curve_name in FetchAllHourlyOutputCurvesRunner.CURVE_TYPES:
+        for curve_name in CurveMetadataService.get_curve_names():
             curve = HourlyOutputCurve.model_validate(
                 {"key": curve_name, "type": cls._infer_curve_type(curve_name)}
             )

--- a/src/pyetm/models/packables/annual_exports_pack.py
+++ b/src/pyetm/models/packables/annual_exports_pack.py
@@ -36,10 +36,10 @@ class AnnualExportsPack(Packable):
         if not export_types:
             return [], []
 
-        # Import the valid export types from the annual_exports model
-        from pyetm.models.annual_exports import ANNUAL_EXPORT_TYPES
+        # Get valid export types from metadata service
+        from pyetm.services.curve_metadata_service import CurveMetadataService
 
-        valid_export_types = set(ANNUAL_EXPORT_TYPES)
+        valid_export_types = set(CurveMetadataService.get_export_names())
 
         # Validate each entry
         valid_types = []

--- a/src/pyetm/models/packables/hourly_output_curves_pack.py
+++ b/src/pyetm/models/packables/hourly_output_curves_pack.py
@@ -50,11 +50,10 @@ class HourlyOutputCurvesPack(Packable):
         carrier_map = HourlyOutputCurves._load_carrier_mappings()
         valid_carriers = set(carrier_map.keys())
 
-        # Get valid curve names from the runner
-        from pyetm.services.scenario_runners.fetch_hourly_output_curves import (
-            FetchAllHourlyOutputCurvesRunner,
-        )
-        valid_curve_names = set(FetchAllHourlyOutputCurvesRunner.CURVE_TYPES)
+        # Get valid curve names from metadata service
+        from pyetm.services.curve_metadata_service import CurveMetadataService
+
+        valid_curve_names = set(CurveMetadataService.get_curve_names())
 
         # Validate each entry
         valid_values = []

--- a/src/pyetm/models/scenario_packer.py
+++ b/src/pyetm/models/scenario_packer.py
@@ -244,7 +244,7 @@ class ScenarioPacker(BaseModel):
             include_input_min_max: Include min/max bounds for inputs. Defaults to False.
             include_users: Include user permissions. Defaults to False.
             include_annual_exports: List of annual export names to include.
-                                   Examples: ["energy_flow", "sankey", "production_parameters"]
+                                   Examples: ["energy_flow", "sankey", "storage_parameters"]
                                    Defaults to None (no annual exports).
 
         Returns:

--- a/src/pyetm/models/session.py
+++ b/src/pyetm/models/session.py
@@ -886,7 +886,7 @@ class Session(Base):
         self, export_names: AnnualExportType | list[AnnualExportType]
     ) -> dict[str, pd.DataFrame]:
         """Get multiple annual exports by name."""
-        validated_names = validate_export_names(cast("str | list[str]", export_names))
+        validated_names = validate_export_names(export_names)
         return self.annual_exports.retrieve_multiple(
             get_client(), self, validated_names
         )

--- a/src/pyetm/services/curve_metadata_service.py
+++ b/src/pyetm/services/curve_metadata_service.py
@@ -1,0 +1,257 @@
+"""Service for fetching and caching curve and export metadata from ETEngine.
+
+Curve and export names are no longer hard-coded in pyetm; they are discovered
+from ETEngine's ``/curves/metadata`` and ``/exports/metadata`` endpoints. This
+service fetches that metadata through the shared ETM client (so it honours the
+same base URL, SSL, proxy and authentication settings as every other request)
+and caches it in memory and on disk.
+
+Note on hidden network access: validators, ``_infer_curve_type`` and
+``create_empty_collection`` rely on this metadata, so those otherwise-pure calls
+trigger a (cached) HTTP request the first time they run. When the API and disk
+cache are both unavailable the service falls back to a built-in default list so
+pyetm keeps working offline and against engines without the metadata endpoints.
+
+Caching strategy:
+- In-memory cache with a TTL (``metadata_cache_ttl``) so long-running processes
+  pick up newly added curves without a restart.
+- Disk cache keyed by base URL, so different environments (pro/beta/local) never
+  share metadata; it survives restarts and brief outages.
+- Built-in defaults as a last resort (may be stale; the API is authoritative).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Optional, cast
+
+import aiohttp
+
+from pyetm.config import curve_registry
+from pyetm.config.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Best-effort fallback used only when the API is unreachable and no disk cache
+# exists (offline, or pointed at an engine without the metadata endpoints). The
+# live API is always preferred and is the source of truth. Curve defaults are
+# derived from curve_registry so the canonical names have a single home.
+_DEFAULT_CURVES: list[dict[str, Any]] = curve_registry.default_curve_metadata()
+
+_DEFAULT_EXPORTS: list[dict[str, Any]] = [
+    {"name": "energy_flow", "description": ""},
+    {"name": "energy_flow_present", "description": ""},
+    {"name": "molecule_flow", "description": ""},
+    {"name": "sankey", "description": ""},
+    {"name": "storage_parameters", "description": ""},
+    {"name": "costs_parameters", "description": ""},
+    # Capacity tables — annual by shape, served from the /exports endpoint.
+    {"name": "electricity_capacities", "description": ""},
+    {"name": "district_heating_capacities", "description": ""},
+    {"name": "hydrogen_capacities", "description": ""},
+    {"name": "network_gas_capacities", "description": ""},
+]
+
+# Per-kind configuration: API path, JSON envelope key, and offline defaults.
+_KINDS: dict[str, dict[str, Any]] = {
+    "curves": {
+        "path": "/curves/metadata",
+        "json_key": "hourly_outputs",
+        "defaults": _DEFAULT_CURVES,
+    },
+    "exports": {
+        "path": "/exports/metadata",
+        "json_key": "annual_exports",
+        "defaults": _DEFAULT_EXPORTS,
+    },
+}
+
+# Exceptions meaning "the API is unreachable/unusable" that trigger the
+# disk-cache/defaults fallback. Programming errors are intentionally not caught.
+_FETCH_ERRORS = (
+    PermissionError,
+    ValueError,
+    ConnectionError,
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+)
+
+
+class CurveMetadataService:
+    """Fetches and caches curve/export metadata from ETEngine.
+
+    All methods are class-level and the cache is shared per process. Use
+    :meth:`clear_cache` to force a refresh (``reload_configuration`` does this
+    automatically when settings change).
+    """
+
+    _cache: dict[str, list[dict[str, Any]]] = {}
+    _fetched_at: dict[str, float] = {}
+    _cache_dir: Optional[Path] = None
+
+    # --------------------------------------------------------------- public API
+
+    @classmethod
+    def get_curve_metadata(cls) -> list[dict[str, Any]]:
+        """Return metadata for all available hourly output curves."""
+        return cls._get_metadata("curves")
+
+    @classmethod
+    def get_export_metadata(cls) -> list[dict[str, Any]]:
+        """Return metadata for all available annual exports."""
+        return cls._get_metadata("exports")
+
+    @classmethod
+    def get_curve_names(cls) -> list[str]:
+        """Return the names of all available curves."""
+        return [curve["name"] for curve in cls.get_curve_metadata()]
+
+    @classmethod
+    def get_export_names(cls) -> list[str]:
+        """Return the names of all available exports."""
+        return [export["name"] for export in cls.get_export_metadata()]
+
+    @classmethod
+    def get_curve_type(cls, curve_name: str) -> Optional[str]:
+        """Return a curve's type (e.g. 'merit_curve'), or None if unknown."""
+        for curve in cls.get_curve_metadata():
+            if curve["name"] == curve_name:
+                return curve.get("type")
+        return None
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clear the in-memory cache (leaves the disk cache in place)."""
+        cls._cache.clear()
+        cls._fetched_at.clear()
+
+    @classmethod
+    def clear_disk_cache(cls) -> None:
+        """Remove disk-cached metadata for the current base URL."""
+        for kind in _KINDS:
+            path = cls._cache_path(kind)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as error:
+                logger.warning("Failed to clear disk cache %s: %s", path, error)
+
+    @classmethod
+    def set_cache_dir(cls, cache_dir: Path) -> None:
+        """Override the directory used for the disk cache (mainly for tests)."""
+        cls._cache_dir = cache_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # ----------------------------------------------------------------- internals
+
+    @classmethod
+    def _get_metadata(cls, kind: str) -> list[dict[str, Any]]:
+        cached = cls._memory_cache(kind)
+        if cached is not None:
+            return cached
+        try:
+            data = cls._fetch(kind)
+        except _FETCH_ERRORS as error:
+            return cls._fallback(kind, error)
+        cls._store(kind, data)
+        return data
+
+    @classmethod
+    def _fetch(cls, kind: str) -> list[dict[str, Any]]:
+        # Imported lazily to avoid an import cycle at module load time.
+        from pyetm.clients import get_client
+
+        config = _KINDS[kind]
+        response = get_client().session.get(
+            config["path"], timeout=get_settings().metadata_timeout
+        )
+        payload = response.json()
+        metadata = cast(list[dict[str, Any]], payload.get(config["json_key"], []))
+        logger.info("Fetched %d %s metadata entries from API", len(metadata), kind)
+        return metadata
+
+    @classmethod
+    def _fallback(cls, kind: str, error: Exception) -> list[dict[str, Any]]:
+        disk = cls._load_from_disk(cls._cache_path(kind))
+        if disk is not None:
+            logger.warning(
+                "Using disk-cached %s metadata after API failure (%s); "
+                "it may be stale if new entries were added.",
+                kind,
+                error,
+            )
+            cls._set_memory(kind, disk)
+            return disk
+
+        logger.warning(
+            "Using built-in default %s metadata: ETEngine is unreachable and no "
+            "disk cache exists (%s). This may be incomplete or stale.",
+            kind,
+            error,
+        )
+        defaults = cast(list[dict[str, Any]], _KINDS[kind]["defaults"])
+        cls._set_memory(kind, defaults)
+        return defaults
+
+    @classmethod
+    def _store(cls, kind: str, data: list[dict[str, Any]]) -> None:
+        cls._set_memory(kind, data)
+        cls._save_to_disk(cls._cache_path(kind), data)
+
+    @classmethod
+    def _memory_cache(cls, kind: str) -> Optional[list[dict[str, Any]]]:
+        data = cls._cache.get(kind)
+        if data is None:
+            return None
+        ttl = get_settings().metadata_cache_ttl
+        if ttl and (time.monotonic() - cls._fetched_at.get(kind, 0.0)) > ttl:
+            return None
+        return data
+
+    @classmethod
+    def _set_memory(cls, kind: str, data: list[dict[str, Any]]) -> None:
+        cls._cache[kind] = data
+        cls._fetched_at[kind] = time.monotonic()
+
+    @classmethod
+    def _cache_dir_path(cls) -> Path:
+        if cls._cache_dir is None:
+            import tempfile
+
+            cls._cache_dir = Path(tempfile.gettempdir()) / "pyetm_cache"
+        cls._cache_dir.mkdir(parents=True, exist_ok=True)
+        return cls._cache_dir
+
+    @classmethod
+    def _cache_path(cls, kind: str) -> Path:
+        # Key the file by base URL so environments never share metadata.
+        digest = hashlib.sha256(str(get_settings().base_url).encode()).hexdigest()[:12]
+        return cls._cache_dir_path() / f"{kind}_metadata_{digest}.json"
+
+    @classmethod
+    def _load_from_disk(cls, path: Path) -> Optional[list[dict[str, Any]]]:
+        try:
+            if not path.exists():
+                return None
+            with open(path, "r", encoding="utf-8") as file:
+                payload = json.load(file)
+        except (OSError, json.JSONDecodeError) as error:
+            logger.warning("Failed to load disk cache %s: %s", path, error)
+            return None
+        # Tolerate both the wrapped ({"data": [...]}) and a legacy bare-list form.
+        if isinstance(payload, dict):
+            return cast(list[dict[str, Any]], payload.get("data", []))
+        return cast(list[dict[str, Any]], payload)
+
+    @classmethod
+    def _save_to_disk(cls, path: Path, data: list[dict[str, Any]]) -> None:
+        payload = {"version": 1, "fetched_at": time.time(), "data": data}
+        try:
+            with open(path, "w", encoding="utf-8") as file:
+                json.dump(payload, file, indent=2)
+        except OSError as error:
+            logger.warning("Failed to save disk cache %s: %s", path, error)

--- a/src/pyetm/services/scenario_runners/fetch_hourly_output_curves.py
+++ b/src/pyetm/services/scenario_runners/fetch_hourly_output_curves.py
@@ -11,7 +11,7 @@ from pyetm.services.scenario_runners.fetch_curves_generic import (
 )
 from ..service_result import ServiceResult
 from pyetm.clients.base_client import BaseClient
-from pyetm.config import curve_registry as registry
+from pyetm.services.curve_metadata_service import CurveMetadataService
 
 
 class DownloadHourlyOutputCurveRunner(BaseRunner[io.StringIO]):
@@ -27,18 +27,17 @@ class DownloadHourlyOutputCurveRunner(BaseRunner[io.StringIO]):
 class FetchAllHourlyOutputCurvesRunner(BaseRunner[Dict[str, io.StringIO]]):
     """Download all known hourly output curves."""
 
-    # Canonical curve keys, single-sourced from the registry. The fetch layer drops any that
-    # do not exist on the target engine dialect (e.g. capacities on a legacy engine).
-    CURVE_TYPES = registry.canonical_names()
-
     @staticmethod
     def run(
         client: BaseClient, scenario: Any, batch_size: int | None = None, **kwargs: Any
     ) -> ServiceResult[Dict[str, Any]]:
+        # Fetch curve types dynamically from metadata service
+        curve_types = CurveMetadataService.get_curve_names()
+
         return GenericCurveBulkRunner.run(
             client,
             scenario,
-            FetchAllHourlyOutputCurvesRunner.CURVE_TYPES,
+            curve_types,
             curve_type="output",
             batch_size=batch_size,
         )

--- a/src/pyetm/types.py
+++ b/src/pyetm/types.py
@@ -2,34 +2,15 @@
 
 from typing import Literal
 
-# Carrier types for hourly output curves
+# Carrier types for hourly output curves (remains static)
 CarrierType = Literal["electricity", "heat", "hydrogen", "methane"]
 
-# Annual export types
-AnnualExportType = Literal[
-    "production_parameters",
-    "energy_flow",
-    "energy_flow_present",
-    "molecule_flow",
-    "sankey",
-    "storage_parameters",
-    "costs_parameters",
-    "electricity_capacities",
-    "district_heating_capacities",
-    "hydrogen_capacities",
-    "network_gas_capacities",
-]
-
-# Hourly curve types
-HourlyCurveType = Literal[
-    "electricity_profiles",
-    "electricity_price",
-    "district_heating_profiles",
-    "agriculture_heat",
-    "household_heat",
-    "buildings_heat",
-    "hydrogen_profiles",
-    "network_gas_profiles",
-    "residual_load",
-    "hydrogen_integral_cost",
-]
+# Export and curve names are server-driven: the set of valid names lives in
+# ETEngine (see services.curve_metadata_service) and can change without a pyetm
+# release. They are therefore plain ``str`` aliases rather than ``Literal`` — we
+# trade static autocomplete for not having to ship a new pyetm version whenever a
+# curve is added. The names are validated at runtime instead; the aliases are
+# kept for readable signatures and to mark intent.
+# Validate with validators.validate_export_names() / validate_hourly_curve_names().
+AnnualExportType = str
+HourlyCurveType = str

--- a/src/pyetm/utils/excel_utils.py
+++ b/src/pyetm/utils/excel_utils.py
@@ -117,7 +117,7 @@ class ExportConfigResolver:
 
             # Annual exports parsing
             from pyetm.models.packables.annual_exports_pack import AnnualExportsPack
-            from pyetm.models.annual_exports import ANNUAL_EXPORT_TYPES
+            from pyetm.services.curve_metadata_service import CurveMetadataService
 
             annual_exports_val = get("annual_exports")
             include_annual_exports = None
@@ -125,8 +125,8 @@ class ExportConfigResolver:
             # First check if it's a boolean (True/False from Excel)
             exports_bool = parse_boolean_field(annual_exports_val)
             if exports_bool is True:
-                # "true" means export all available annual export types (all 7 types)
-                include_annual_exports = list(ANNUAL_EXPORT_TYPES)
+                # "true" means export all annual export types the engine offers
+                include_annual_exports = CurveMetadataService.get_export_names()
                 logger.info("EXPORT_CONFIG: annual_exports set to 'true', exporting all types: %s", include_annual_exports)
             elif exports_bool is False:
                 include_annual_exports = None
@@ -239,22 +239,26 @@ class ExportConfigResolver:
         else:
             output_carriers = parse_carriers(carriers_val) or parse_carriers(exports_val)
 
-        # Annual exports parsing
-        VALID_ANNUAL_EXPORT_TYPES = {"energy_flow", "sankey", "production_parameters"}
+        # Annual exports parsing. Valid names are discovered from ETEngine (see
+        # CurveMetadataService) so this path stays in sync with the API rather
+        # than hard-coding a list.
+        from pyetm.services.curve_metadata_service import CurveMetadataService
+
+        valid_annual_export_types = set(CurveMetadataService.get_export_names())
         annual_exports_val = get_cell_value("annual_exports")
         include_annual_exports = None
 
         # First check if it's a boolean (True/False from Excel)
         exports_bool = parse_bool(annual_exports_val)
         if exports_bool is True:
-            include_annual_exports = ["energy_flow", "sankey", "production_parameters"]
+            include_annual_exports = CurveMetadataService.get_export_names()
         elif exports_bool is False:
             include_annual_exports = None
         elif isinstance(annual_exports_val, str):
             # Parse as comma-separated list
             parsed = parse_carriers(annual_exports_val)
             if parsed:
-                valid_exports = [e for e in parsed if e in VALID_ANNUAL_EXPORT_TYPES]
+                valid_exports = [e for e in parsed if e in valid_annual_export_types]
                 include_annual_exports = valid_exports if valid_exports else None
 
         config = ExportConfig(

--- a/src/pyetm/validators.py
+++ b/src/pyetm/validators.py
@@ -1,6 +1,6 @@
 """Validation utilities for pyetm curve and export types.
 
-This module provides validation functionsthat raise clear ValueError exceptions
+This module provides validation functions that raise clear ValueError exceptions
 when invalid curve types, carrier types, or export names are provided.
 """
 
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import TypeVar, get_args, Any, cast
 from pydantic import TypeAdapter, ValidationError
-from pyetm.types import AnnualExportType, CarrierType, HourlyCurveType
+from pyetm.types import CarrierType
+from pyetm.config import curve_registry
+from pyetm.services.curve_metadata_service import CurveMetadataService
 
 T = TypeVar("T")
 
@@ -47,6 +49,24 @@ def _validate_literal_type(
         ) from None
 
 
+def _validate_against_list(
+    value: str | list[str],
+    valid_values: list[str],
+    error_label: str,
+) -> list[str]:
+    """Generic helper to validate values against a list of valid values."""
+    values_to_validate = [value] if isinstance(value, str) else value
+
+    invalid = [v for v in values_to_validate if v not in valid_values]
+    if invalid:
+        valid_types = ", ".join(valid_values)
+        raise ValueError(
+            f"Invalid {error_label}: {invalid}. Valid types: {valid_types}"
+        )
+
+    return values_to_validate
+
+
 def validate_carrier_type(carrier_type: str) -> str:
     """Validate that carrier_type is a valid carrier type."""
     return cast(
@@ -56,21 +76,29 @@ def validate_carrier_type(carrier_type: str) -> str:
 
 
 def validate_export_names(export_names: str | list[str]) -> list[str]:
-    """Validate and normalize export names."""
-    return cast(
-        list[str], _validate_literal_type(export_names, AnnualExportType, "export names")
-    )
+    """
+    Validate and normalize export names.
+
+    Fetches valid export names from ETEngine metadata API.
+
+    Note: may trigger a cached metadata fetch from ETEngine on first use
+    (falls back to curve_registry / built-in defaults offline).
+    """
+    valid_exports = CurveMetadataService.get_export_names()
+    return _validate_against_list(export_names, valid_exports, "export names")
 
 
 def validate_hourly_curve_names(curve_names: str | list[str]) -> list[str]:
-    """Validate and normalize hourly curve names.
-
-    Legacy engine names (e.g. ``merit_order``, ``heat_network``) are accepted and normalized.
     """
-    from pyetm.config import curve_registry as registry
+    Validate and normalize hourly curve names.
 
-    names = [curve_names] if isinstance(curve_names, str) else curve_names
-    canonical = [registry.accept_alias(name) for name in names]
-    return cast(
-        list[str], _validate_literal_type(canonical, HourlyCurveType, "curve names")
-    )
+    Legacy/old engine names (e.g. ``merit_order``) are resolved to their canonical
+    key first, then validated against the curve names from the ETEngine metadata API.
+
+    Note: may trigger a cached metadata fetch from ETEngine on first use
+    (falls back to curve_registry / built-in defaults offline).
+    """
+    names = [curve_names] if isinstance(curve_names, str) else list(curve_names)
+    normalized = [curve_registry.accept_alias(name) for name in names]
+    valid_curves = CurveMetadataService.get_curve_names()
+    return _validate_against_list(normalized, valid_curves, "curve names")

--- a/tests/config/test_curve_registry.py
+++ b/tests/config/test_curve_registry.py
@@ -51,15 +51,24 @@ class TestBuildPath:
     def test_curves_endpoint(self, name, expected):
         assert registry.build_path(42, name) == expected
 
+    def test_capacities_are_not_curves(self):
+        # Capacities are annual exports, not hourly curves; they are not in the registry.
+        assert "electricity_capacities" not in registry.canonical_names()
+
+
 class TestMetadata:
     def test_canonical_names_complete(self):
         names = registry.canonical_names()
         assert "electricity_profiles" in names
+        assert "district_heating_profiles" in names
         assert "heat_network_profiles" not in names  # the wrong guessed name is not canonical
-        assert "electricity_capacities" not in names  # capacity tables are annual exports
+        # Capacities moved to the annual-export cluster.
+        assert "district_heating_capacities" not in names
 
     def test_curve_type_for(self):
         assert registry.curve_type_for("merit_order") == "merit_curve"
+        # Capacities are not curves, so they fall through to the generic type.
+        assert registry.curve_type_for("electricity_capacities") == "output_curve"
         assert registry.curve_type_for("unknown") == "output_curve"
 
     def test_carrier_to_canonical(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,61 @@ def clear_client_caches():
     reload_configuration()
 
 
+# Mock CurveMetadataService to prevent API calls during tests
+@pytest.fixture(autouse=True)
+def mock_curve_metadata_service(request, monkeypatch):
+    """Mock CurveMetadataService to return test data without making API calls."""
+    # Skip mocking for tests that specifically test the CurveMetadataService
+    if "test_curve_metadata_service" in str(request.fspath):
+        return
+
+    from pyetm.config import curve_registry
+    from pyetm.services.curve_metadata_service import CurveMetadataService
+
+    # Derive curves from the registry so the mock can never drift from the canonical names.
+    test_curves = curve_registry.default_curve_metadata()
+
+    test_exports = [
+        {"name": "energy_flow", "description": "Test export"},
+        {"name": "energy_flow_present", "description": "Test export"},
+        {"name": "molecule_flow", "description": "Test export"},
+        {"name": "sankey", "description": "Test export"},
+        {"name": "storage_parameters", "description": "Test export"},
+        {"name": "costs_parameters", "description": "Test export"},
+        {"name": "electricity_capacities", "description": "Test export"},
+        {"name": "district_heating_capacities", "description": "Test export"},
+        {"name": "hydrogen_capacities", "description": "Test export"},
+        {"name": "network_gas_capacities", "description": "Test export"},
+    ]
+
+    # Mock the methods to return test data
+    monkeypatch.setattr(
+        CurveMetadataService,
+        "get_curve_metadata",
+        lambda: test_curves
+    )
+    monkeypatch.setattr(
+        CurveMetadataService,
+        "get_export_metadata",
+        lambda: test_exports
+    )
+    monkeypatch.setattr(
+        CurveMetadataService,
+        "get_curve_names",
+        lambda: [c["name"] for c in test_curves]
+    )
+    monkeypatch.setattr(
+        CurveMetadataService,
+        "get_export_names",
+        lambda: [e["name"] for e in test_exports]
+    )
+    monkeypatch.setattr(
+        CurveMetadataService,
+        "get_curve_type",
+        lambda curve_name: next((c["type"] for c in test_curves if c["name"] == curve_name), None)
+    )
+
+
 # Lazy‐import BaseClient
 @pytest.fixture
 def client():

--- a/tests/exporters/test_excel_exporter.py
+++ b/tests/exporters/test_excel_exporter.py
@@ -406,7 +406,7 @@ class TestAnnualExportsWriter:
 
         output_path = tmp_path / "exports.xlsx"
         exports_data = {
-            "production_parameters": {
+            "storage_parameters": {
                 "scenario1": pd.DataFrame({
                     "technology": ["solar_pv"],
                     "capacity": [100.0]
@@ -424,7 +424,7 @@ class TestAnnualExportsWriter:
 
         # Verify file was created successfully
         assert output_path.exists()
-        df = pd.read_excel(str(output_path), sheet_name="PRODUCTION_PARAMETERS", header=[0, 1])
+        df = pd.read_excel(str(output_path), sheet_name="STORAGE_PARAMETERS", header=[0, 1])
 
         # Verify scenarios appear as top-level columns
         assert "scenario1" in df.columns.get_level_values(0)

--- a/tests/models/test_annual_exports.py
+++ b/tests/models/test_annual_exports.py
@@ -123,3 +123,30 @@ heat,200,180""")
     # Verify we can access rows by index
     assert df.loc["electricity", "output"] == 1000
     assert df.loc["gas", "demand"] == 450
+
+
+def test_capacity_is_a_valid_annual_export_and_parses_as_a_table():
+    """Capacities are annual exports: discovered as exports and parsed as a table."""
+    from io import StringIO
+    from pyetm.models.annual_exports import AnnualExport
+
+    # from_name accepts it without an 'unknown export' warning (capacities are exports).
+    export = AnnualExport.from_name("electricity_capacities")
+    assert not export.warnings
+
+    csv_data = StringIO(
+        "key,installed_capacity,peak_capacity\n"
+        "wind_turbine.output (MW),200.0,8.0\n"
+        "electrolyser.input (MW),150.0,4.5\n"
+    )
+    result = Mock(success=True, data=csv_data, errors=None)
+
+    with patch(
+        "pyetm.models.annual_exports.DownloadAnnualExportRunner.run", return_value=result
+    ):
+        df = export.retrieve(client=Mock(), scenario=Mock())
+
+    assert df is not None
+    assert list(df.index) == ["wind_turbine.output (MW)", "electrolyser.input (MW)"]
+    assert list(df.columns) == ["installed_capacity", "peak_capacity"]
+    assert df.loc["wind_turbine.output (MW)", "peak_capacity"] == 8.0

--- a/tests/models/test_hourly_output_curves.py
+++ b/tests/models/test_hourly_output_curves.py
@@ -234,6 +234,8 @@ def test_hourly_output_curves_infer_curve_type():
     """Test _infer_curve_type method"""
     assert HourlyOutputCurves._infer_curve_type("electricity_price") == "price_curve"
     assert HourlyOutputCurves._infer_curve_type("electricity_profiles") == "merit_curve"
+    # Capacities are annual exports, not hourly curves -> generic fallback type.
+    assert HourlyOutputCurves._infer_curve_type("electricity_capacities") == "output_curve"
     assert HourlyOutputCurves._infer_curve_type("unknown_curve") == "output_curve"
     # Test deprecated curve names (should still work with warning)
     assert HourlyOutputCurves._infer_curve_type("merit_order") == "merit_curve"
@@ -269,18 +271,10 @@ def test_hourly_output_curves_fetch_all():
 
 def test_hourly_output_curves_create_empty_collection():
     """Test create_empty_collection class method"""
-    # Create a mock for the FetchAllHourlyOutputCurvesRunner class
-    mock_runner_class = Mock()
-    mock_runner_class.CURVE_TYPES = ["curve1", "curve2"]
-
-    # Mock the import that happens inside create_empty_collection
-    with patch.dict(
-        "sys.modules",
-        {
-            "pyetm.services.scenario_runners.fetch_hourly_output_curves": Mock(
-                FetchAllHourlyOutputCurvesRunner=mock_runner_class
-            )
-        },
+    # Mock CurveMetadataService.get_curve_names() to return test curves
+    with patch(
+        "pyetm.models.hourly_output_curves.CurveMetadataService.get_curve_names",
+        return_value=["curve1", "curve2"]
     ):
         curves = HourlyOutputCurves.create_empty_collection()
 

--- a/tests/models/test_packables.py
+++ b/tests/models/test_packables.py
@@ -92,9 +92,8 @@ class TestAnnualExportsPackValidation:
     """Test validation of annual exports configuration."""
 
     def test_validate_export_types_with_all_valid_types(self):
-        """All 7 valid export types should pass through."""
+        """All valid export types should pass through."""
         config = [
-            "production_parameters",
             "energy_flow",
             "energy_flow_present",
             "molecule_flow",
@@ -109,7 +108,7 @@ class TestAnnualExportsPackValidation:
 
     def test_validate_export_types_with_subset_of_valid_types(self):
         """Subset of valid types should pass through."""
-        config = ["energy_flow", "sankey", "production_parameters"]
+        config = ["energy_flow", "sankey", "storage_parameters"]
         valid_values, warnings = AnnualExportsPack.validate_export_types(config)
 
         assert set(valid_values) == set(config)
@@ -117,10 +116,10 @@ class TestAnnualExportsPackValidation:
 
     def test_validate_export_types_with_invalid_type(self):
         """Invalid export types should be filtered with warnings."""
-        config = ["energy_flow", "sankeyyy", "production_parameters"]
+        config = ["energy_flow", "sankeyyy", "storage_parameters"]
         valid_values, warnings = AnnualExportsPack.validate_export_types(config)
 
-        assert set(valid_values) == {"energy_flow", "production_parameters"}
+        assert set(valid_values) == {"energy_flow", "storage_parameters"}
         assert len(warnings) == 1
         assert "sankeyyy" in warnings[0]
         assert "Invalid" in warnings[0]

--- a/tests/models/test_scenario.py
+++ b/tests/models/test_scenario.py
@@ -1569,7 +1569,7 @@ def test_get_annual_exports_invalid_export_name(scenario):
         scenario.get_annual_exports("invalid_export")
 
     assert "Invalid export names: ['invalid_export']" in str(exc_info.value)
-    assert "production_parameters" in str(exc_info.value)
+    assert "storage_parameters" in str(exc_info.value)
 
 
 def test_get_annual_exports_mixed_valid_and_invalid(scenario):

--- a/tests/models/test_scenario_packer.py
+++ b/tests/models/test_scenario_packer.py
@@ -697,8 +697,15 @@ class TestExportConfigResolver:
 
         assert config.include_annual_exports == [
             "energy_flow",
+            "energy_flow_present",
+            "molecule_flow",
             "sankey",
-            "production_parameters",
+            "storage_parameters",
+            "costs_parameters",
+            "electricity_capacities",
+            "district_heating_capacities",
+            "hydrogen_capacities",
+            "network_gas_capacities",
         ]
 
     def test_parse_config_from_series_annual_exports_false(self):
@@ -740,7 +747,6 @@ class TestExportConfigResolver:
 
         assert config is not None
         assert config.include_annual_exports == [
-            "production_parameters",
             "energy_flow",
             "energy_flow_present",
             "molecule_flow",
@@ -765,7 +771,6 @@ class TestExportConfigResolver:
 
         assert config is not None
         assert config.include_annual_exports == [
-            "production_parameters",
             "energy_flow",
             "energy_flow_present",
             "molecule_flow",
@@ -1436,7 +1441,7 @@ class TestPackerValidation:
             packer.annual_exports(exports="invalid_export")
 
         assert "Invalid export names: ['invalid_export']" in str(exc_info.value)
-        assert "production_parameters" in str(exc_info.value)
+        assert "storage_parameters" in str(exc_info.value)
 
     def test_annual_exports_mixed_valid_invalid(self):
         """Test that annual_exports raises ValueError for mixed valid/invalid"""

--- a/tests/services/scenario_runners/test_fetch_curves_generic.py
+++ b/tests/services/scenario_runners/test_fetch_curves_generic.py
@@ -68,7 +68,6 @@ def test_renamed_curve_uses_old_wire_name():
     assert patched.call_args[0][1][0]["path"] == "/scenarios/123/curves/heat_network.csv"
 
 
-
 def test_generic_curve_download_runner_http_error():
     mock_client, mock_scenario = _client_scenario()
 

--- a/tests/services/test_curve_metadata_service.py
+++ b/tests/services/test_curve_metadata_service.py
@@ -1,0 +1,317 @@
+"""Tests for the CurveMetadataService.
+
+The service fetches metadata through the shared ETM client (``get_client()``),
+so these tests stub that client's session rather than mocking ``requests``.
+"""
+
+import json
+
+import pytest
+
+from pyetm.services.curve_metadata_service import (
+    CurveMetadataService,
+    _DEFAULT_CURVES,
+    _DEFAULT_EXPORTS,
+)
+
+CURVES_PATH = "/curves/metadata"
+EXPORTS_PATH = "/exports/metadata"
+
+
+class _FakeResponse:
+    """Minimal stand-in for ETMResponse."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Stand-in for ETMSession.get used by CurveMetadataService."""
+
+    def __init__(self):
+        self._responses = {}
+        self._error = None
+        self.calls = 0
+
+    def set_responses(self, responses):
+        self._responses = responses
+        self._error = None
+
+    def set_error(self, error):
+        self._error = error
+
+    def get(self, path, **kwargs):
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        if path not in self._responses:
+            raise ConnectionError(f"unexpected metadata path: {path}")
+        return _FakeResponse(self._responses[path])
+
+
+class _FakeClient:
+    def __init__(self, session):
+        self.session = session
+
+
+@pytest.fixture(autouse=True)
+def service(tmp_path, monkeypatch):
+    """Isolate the cache and route fetches to a controllable fake session."""
+    CurveMetadataService.clear_cache()
+    CurveMetadataService.set_cache_dir(tmp_path)
+
+    session = _FakeSession()
+    monkeypatch.setattr("pyetm.clients.get_client", lambda: _FakeClient(session))
+
+    yield session
+
+    CurveMetadataService.clear_cache()
+    CurveMetadataService.clear_disk_cache()
+
+
+class TestCurveMetadataService:
+    """Tests for CurveMetadataService class."""
+
+    def test_get_curve_metadata_from_api(self, service):
+        service.set_responses(
+            {
+                CURVES_PATH: {
+                    "hourly_outputs": [
+                        {
+                            "name": "electricity_profiles",
+                            "type": "merit_curve",
+                            "description": "Test description",
+                        }
+                    ]
+                }
+            }
+        )
+
+        metadata = CurveMetadataService.get_curve_metadata()
+
+        assert len(metadata) == 1
+        assert metadata[0]["name"] == "electricity_profiles"
+        assert metadata[0]["type"] == "merit_curve"
+
+    def test_get_curve_metadata_caches_result(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "test", "type": "t", "description": "d"}]}}
+        )
+
+        CurveMetadataService.get_curve_metadata()
+        CurveMetadataService.get_curve_metadata()
+
+        assert service.calls == 1
+
+    def test_in_memory_cache_expires_after_ttl(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "x", "type": "t", "description": "d"}]}}
+        )
+
+        CurveMetadataService.get_curve_metadata()
+        assert service.calls == 1
+
+        # Simulate the cached entry being older than the TTL.
+        CurveMetadataService._fetched_at["curves"] -= 10_000
+
+        CurveMetadataService.get_curve_metadata()
+        assert service.calls == 2
+
+    def test_get_curve_metadata_saves_to_disk(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "test", "type": "t", "description": "d"}]}}
+        )
+
+        CurveMetadataService.get_curve_metadata()
+
+        cache_file = CurveMetadataService._cache_path("curves")
+        assert cache_file.exists()
+
+        payload = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert payload["data"][0]["name"] == "test"
+        assert "fetched_at" in payload
+
+    def test_uses_disk_cache_on_api_failure(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "cached_curve", "type": "t", "description": "d"}]}}
+        )
+        CurveMetadataService.get_curve_metadata()
+
+        CurveMetadataService.clear_cache()
+        service.set_error(ConnectionError("server down"))
+
+        metadata = CurveMetadataService.get_curve_metadata()
+
+        assert len(metadata) == 1
+        assert metadata[0]["name"] == "cached_curve"
+
+    def test_falls_back_to_defaults_when_no_cache(self, service):
+        service.set_error(ConnectionError("offline"))
+
+        metadata = CurveMetadataService.get_curve_metadata()
+
+        assert [c["name"] for c in metadata] == [c["name"] for c in _DEFAULT_CURVES]
+
+    def test_falls_back_to_defaults_against_old_engine_404(self, service):
+        # The shared session raises ValueError for 4xx responses; an engine
+        # without the metadata endpoint (404) must degrade to defaults, not crash.
+        service.set_error(ValueError("404: Not Found"))
+
+        curve_names = CurveMetadataService.get_curve_names()
+        export_names = CurveMetadataService.get_export_names()
+
+        assert "electricity_profiles" in curve_names
+        # Capacities are annual exports, not hourly curves.
+        assert "electricity_capacities" not in curve_names
+        assert "electricity_capacities" in export_names
+
+    def test_get_export_metadata_from_api(self, service):
+        service.set_responses(
+            {EXPORTS_PATH: {"annual_exports": [{"name": "energy_flow", "description": "Test"}]}}
+        )
+
+        metadata = CurveMetadataService.get_export_metadata()
+
+        assert len(metadata) == 1
+        assert metadata[0]["name"] == "energy_flow"
+
+    def test_get_export_metadata_caches_result(self, service):
+        service.set_responses(
+            {EXPORTS_PATH: {"annual_exports": [{"name": "test", "description": "d"}]}}
+        )
+
+        CurveMetadataService.get_export_metadata()
+        CurveMetadataService.get_export_metadata()
+
+        assert service.calls == 1
+
+    def test_export_metadata_uses_disk_cache_on_api_failure(self, service):
+        service.set_responses(
+            {EXPORTS_PATH: {"annual_exports": [{"name": "cached_export", "description": "d"}]}}
+        )
+        CurveMetadataService.get_export_metadata()
+
+        CurveMetadataService.clear_cache()
+        service.set_error(ConnectionError("server down"))
+
+        metadata = CurveMetadataService.get_export_metadata()
+
+        assert metadata[0]["name"] == "cached_export"
+
+    def test_export_metadata_falls_back_to_defaults(self, service):
+        service.set_error(ConnectionError("offline"))
+
+        metadata = CurveMetadataService.get_export_metadata()
+
+        assert [e["name"] for e in metadata] == [e["name"] for e in _DEFAULT_EXPORTS]
+
+    def test_get_curve_names(self, service):
+        service.set_responses(
+            {
+                CURVES_PATH: {
+                    "hourly_outputs": [
+                        {"name": "curve1", "type": "t1", "description": "d1"},
+                        {"name": "curve2", "type": "t2", "description": "d2"},
+                    ]
+                }
+            }
+        )
+
+        assert CurveMetadataService.get_curve_names() == ["curve1", "curve2"]
+
+    def test_get_export_names(self, service):
+        service.set_responses(
+            {
+                EXPORTS_PATH: {
+                    "annual_exports": [
+                        {"name": "export1", "description": "d1"},
+                        {"name": "export2", "description": "d2"},
+                    ]
+                }
+            }
+        )
+
+        assert CurveMetadataService.get_export_names() == ["export1", "export2"]
+
+    def test_get_curve_type(self, service):
+        service.set_responses(
+            {
+                CURVES_PATH: {
+                    "hourly_outputs": [
+                        {"name": "electricity_profiles", "type": "merit_curve", "description": "d"}
+                    ]
+                }
+            }
+        )
+
+        assert CurveMetadataService.get_curve_type("electricity_profiles") == "merit_curve"
+
+    def test_get_curve_type_not_found(self, service):
+        service.set_responses({CURVES_PATH: {"hourly_outputs": []}})
+
+        assert CurveMetadataService.get_curve_type("unknown_curve") is None
+
+    def test_clear_cache_forces_refetch(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "test", "type": "t", "description": "d"}]}}
+        )
+
+        CurveMetadataService.get_curve_metadata()
+        CurveMetadataService.clear_cache()
+        CurveMetadataService.get_curve_metadata()
+
+        assert service.calls == 2
+
+    def test_clear_disk_cache(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "test", "type": "t", "description": "d"}]}}
+        )
+        CurveMetadataService.get_curve_metadata()
+
+        cache_file = CurveMetadataService._cache_path("curves")
+        assert cache_file.exists()
+
+        CurveMetadataService.clear_disk_cache()
+        assert not cache_file.exists()
+
+
+class TestCacheNamespacing:
+    """The cache must not be shared across environments (base URLs)."""
+
+    def test_cache_path_namespaced_by_base_url(self, monkeypatch):
+        class _Settings:
+            base_url = "https://a.example.com/api/v3"
+            metadata_timeout = 5.0
+            metadata_cache_ttl = 3600.0
+
+        class _OtherSettings(_Settings):
+            base_url = "https://b.example.com/api/v3"
+
+        monkeypatch.setattr(
+            "pyetm.services.curve_metadata_service.get_settings", lambda: _Settings()
+        )
+        path_a = CurveMetadataService._cache_path("curves")
+
+        monkeypatch.setattr(
+            "pyetm.services.curve_metadata_service.get_settings", lambda: _OtherSettings()
+        )
+        path_b = CurveMetadataService._cache_path("curves")
+
+        assert path_a.name.startswith("curves_metadata_")
+        assert path_a != path_b
+
+    def test_reload_configuration_clears_in_memory_cache(self, service):
+        service.set_responses(
+            {CURVES_PATH: {"hourly_outputs": [{"name": "x", "type": "t", "description": "d"}]}}
+        )
+        CurveMetadataService.get_curve_metadata()
+        assert CurveMetadataService._cache
+
+        from pyetm.config.settings import reload_configuration
+
+        reload_configuration()
+
+        assert CurveMetadataService._cache == {}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -69,14 +69,13 @@ class TestValidateExportNames:
 
     def test_list_of_valid_exports(self):
         """Test that list of valid exports is accepted."""
-        exports = ["energy_flow", "sankey", "production_parameters"]
+        exports = ["energy_flow", "sankey", "storage_parameters"]
         result = validate_export_names(exports)
         assert result == exports
 
     def test_all_valid_export_types(self):
         """Test that all valid export types are accepted."""
         all_exports = [
-            "production_parameters",
             "energy_flow",
             "energy_flow_present",
             "molecule_flow",
@@ -94,7 +93,7 @@ class TestValidateExportNames:
 
         error_message = str(exc_info.value)
         assert "Invalid export names: ['invalid_export']" in error_message
-        assert "production_parameters" in error_message
+        assert "storage_parameters" in error_message
         assert "energy_flow" in error_message
 
     def test_mixed_valid_and_invalid_exports(self):
@@ -134,7 +133,7 @@ class TestValidateCurveNames:
         assert result == curves
 
     def test_all_valid_curve_types(self):
-        """Test that all valid curve types are accepted."""
+        """Test that all valid (hourly) curve types are accepted."""
         all_curves = [
             "electricity_profiles",
             "electricity_price",
@@ -149,6 +148,18 @@ class TestValidateCurveNames:
         ]
         result = validate_hourly_curve_names(all_curves)
         assert result == all_curves
+
+    def test_capacities_are_exports_not_hourly_curves(self):
+        """Capacities are annual exports: rejected as hourly curves, valid as exports."""
+        capacities = [
+            "electricity_capacities",
+            "district_heating_capacities",
+            "hydrogen_capacities",
+            "network_gas_capacities",
+        ]
+        with pytest.raises(ValueError):
+            validate_hourly_curve_names(capacities)
+        assert validate_export_names(capacities) == capacities
 
     def test_legacy_and_old_names_normalized(self):
         """Legacy/old engine names are accepted and normalized to canonical keys."""


### PR DESCRIPTION
#### Context
Fetch curves from the added metadata endpoints in etengine, with a fallback for version 2025-01. This way available curves and exports are discovered via the endpoint and cached, and then that information is re-used when fetching outputs.

#### Implemented changes
- Adds `CurveMetadataService` — fetches `/curves/metadata` and `/exports/metadata` from ETEngine at runtime, with in-memory TTL cache, disk cache keyed by base URL, and hardcoded fallback defaults for stable version use
- Adds `CurveRegistry` with `canonical` (new name) / `wire` (on-wire name) split so curve requests remain compatible with `2025-01` engines that only know old names (e.g. `merit_order`, not `electricity_profiles`)
- Replaces hard-coded export and curve name lists throughout `validators.py`, `annual_exports.py`, `hourly_output_curves.py`, and `excel_utils.py`

#### Related
Goes with [this etengine PR](https://github.com/quintel/etengine/pull/1774) and [this documentation PR](https://github.com/quintel/documentation/pull/337)

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
